### PR TITLE
Add common gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,71 @@
 # Bazel output artifacts
 bazel-*
 
-# VSCode settings.
-.vscode
+# IDE related
+.idea/
+.vscode/
+.swp
+
+# Some users might still want to generate this via `go mod vendor`
+# even though Go Modules doesn't generate it by default
+vendor/
+
+# Items below are adopted from https://github.com/github/gitignore/blob/master/Go.gitignore
+
+## Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+## Test binary, built with `go test -c`
+*.test
+
+## Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Items below are adopted from https://github.com/github/gitignore/blob/master/Global/Linux.gitignore
+
+*~
+
+## temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+## KDE directory preferences
+.directory
+
+## Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+## .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# Items below are adopted from https://github.com/github/gitignore/blob/master/Global/macOS.gitignore
+
+## General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+## Icon must end with two \r
+Icon
+
+## Thumbnails
+._*
+
+## Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+## Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
These are mostly adopted from https://github.com/github/gitignore and almost identical to what we have in kubeflow/common [here](https://github.com/kubeflow/common/blob/master/.gitignore), except for bazel related artifacts that this project use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/23)
<!-- Reviewable:end -->
