### PR TITLE
Update the swagger generation code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,12 @@ metadata-docker-image:
 	docker build -t gcr.io/kubeflow-images-public/metadata .
 
 swagger-py-client:
-	wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/3.0.0-rc1/swagger-codegen-cli-3.0.0-rc1.jar -O swagger-codegen-cli.jar && \
-	java -jar /bin/swagger-codegen-cli.jar generate \
+	mkdir -p /tmp/swagger
+	wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.5/swagger-codegen-cli-2.4.5.jar -O /tmp/swagger/swagger-codegen-cli.jar && \
+        java -jar /tmp/swagger/swagger-codegen-cli.jar generate \
     -i api/service.swagger.json \
     -l python \
-    -o swagger_clients/python && \
-	rm swagger-codegen-cli.jar
+    -o /tmp/swagger && \
+        rm -rf python_client/swagger_client && \
+        cp -r /tmp/swagger/swagger_client python_client/ && \
+        rm -rf /tmp/swagger


### PR DESCRIPTION
Change the make file to generate the swagger client stub for metadata REST endpoints.

Test it locally, the python client can talk to the REST endpoints via the generated swagger_client.

The code structure looks like:

```
python_client
├── concepts.png
├── __init__.py
├── metadata.py
├── README.md
├── swagger_client           ###### generated swagger client
│   ├── api
│   │   ├── __init__.py
│   │   └── metadata_service_api.py
│   ├── api_client.py
│   ├── configuration.py
│   ├── __init__.py
│   ├── models
│   │   ├── api_artifact_type.py
│   │   ├── api_create_artifact_type_response.py
│   │   ├── api_double_type.py
│   │   ├── api_get_artifact_type_response.py
│   │   ├── api_int_type.py
│   │   ├── api_list_artifact_types_response.py
│   │   ├── api_namespace.py
│   │   ├── api_string_type.py
│   │   ├── api_type.py
│   │   └── __init__.py
│   └── rest.py

└── tests
    ├── __init__.py
    ├── run_tests.sh
    └── test.py
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/38)
<!-- Reviewable:end -->
