### PR TITLE
Add list artifacts by type into Python SDK

### DIFF
--- a/sdk/python/kfmd/metadata.py
+++ b/sdk/python/kfmd/metadata.py
@@ -22,6 +22,10 @@ This module conatins Python API for logging metadata of machine learning
 workflows to Kubeflow Metadata service.
 """
 
+WORKSPACE_PROPERTY_NAME = '__kf_workspace__'
+RUN_PROPERTY_NAME = '__kf_run__'
+ALL_META_PROPERTY_NAME = '__ALL_META__'
+
 class Workspace(object):
   """
   Groups a set of runs of pipelines, notebooks and their related artifacts
@@ -65,27 +69,34 @@ class Workspace(object):
     if not response.artifacts:
       return results
     for artifact in response.artifacts:
-      results.append(self._flat(artifact))
+      flat = self._flat(artifact)
+      if "workspace" in flat and flat["workspace"] == self.name:
+        results.append(flat)
     return results
 
   def _flat(self, artifact):
     result = {
       "id": artifact.id,
     }
+    if artifact.custom_properties != None:
+        if WORKSPACE_PROPERTY_NAME in artifact.custom_properties:
+          result["workspace"] = artifact.custom_properties[WORKSPACE_PROPERTY_NAME].string_value
+        if RUN_PROPERTY_NAME in artifact.custom_properties:
+          result["run"] = artifact.custom_properties[RUN_PROPERTY_NAME].string_value
     if not artifact.properties:
       return result
     for k,v in artifact.properties.items():
-      if k != "__ALL_META__":
+      if k != ALL_META_PROPERTY_NAME:
         if v.string_value != None:
           result[k] = v.string_value
         elif v.int_value != None:
           result[k] = v.int_value
         else:
           result[k] = v.double_value
-    if not "__ALL_META__" in artifact.properties:
+    if not ALL_META_PROPERTY_NAME in artifact.properties:
       return result
-    # Pick up all nested object stored in the __ALL_META__ field.
-    all_meta = artifact.properties["__ALL_META__"].string_value
+    # Pick up all nested objects stored in the __ALL_META__ field.
+    all_meta = artifact.properties[ALL_META_PROPERTY_NAME].string_value
     for k, v in json.loads(all_meta).items():
       if not k in result:
         result[k] = v
@@ -96,9 +107,6 @@ class Run(object):
   Captures a run of pipeline or notebooks in a workspace and provides logging
   methods for artifacts.
   """
-
-  WORKSPACE_PROPERTY_NAME = '__kf_workspace__'
-  RUN_PROPERTY_NAME = '__kf_run__'
 
   def __init__(self, workspace=None, name=None, description=None):
     """
@@ -135,17 +143,17 @@ class Run(object):
     serialization = artifact.serialization()
     if serialization.custom_properties == None:
           serialization.custom_properties = {}
-    if self.WORKSPACE_PROPERTY_NAME in serialization.custom_properties:
+    if WORKSPACE_PROPERTY_NAME in serialization.custom_properties:
           raise ValueError("custom_properties contains reserved key %s"
-                           % self.WORKSPACE_PROPERTY_NAME)
-    if self.RUN_PROPERTY_NAME in serialization.custom_properties:
+                           % WORKSPACE_PROPERTY_NAME)
+    if RUN_PROPERTY_NAME in serialization.custom_properties:
       raise ValueError("custom_properties contains reserved key %s"
-                       % self.RUN_PROPERTY_NAME)
+                       % RUN_PROPERTY_NAME)
     serialization.custom_properties[
-        self.WORKSPACE_PROPERTY_NAME] = openapi_client.MlMetadataValue(
+        WORKSPACE_PROPERTY_NAME] = openapi_client.MlMetadataValue(
         string_value=self.workspace.name)
     serialization.custom_properties[
-        self.RUN_PROPERTY_NAME] = openapi_client.MlMetadataValue(
+        RUN_PROPERTY_NAME] = openapi_client.MlMetadataValue(
         string_value=self.name)
     response = self.workspace._client.create_artifact(
         parent=artifact.ARTIFACT_TYPE_NAME,
@@ -212,7 +220,7 @@ class DataSet(object):
                 openapi_client.MlMetadataValue(string_value=self.version),
             "owner":
                 openapi_client.MlMetadataValue(string_value=self.owner),
-            "__ALL_META__":
+            ALL_META_PROPERTY_NAME:
                 openapi_client.MlMetadataValue(string_value=json.dumps(self.__dict__)),
         })
     return data_set_artifact
@@ -279,7 +287,7 @@ class Model(object):
                 openapi_client.MlMetadataValue(string_value=self.version),
             "owner":
                 openapi_client.MlMetadataValue(string_value=self.owner),
-            "__ALL_META__":
+            ALL_META_PROPERTY_NAME:
                 openapi_client.MlMetadataValue(string_value=json.dumps(self.__dict__)),
         })
     return model_artifact
@@ -355,7 +363,7 @@ class Metrics(object):
                 openapi_client.MlMetadataValue(string_value=self.model_id),
             "owner":
                 openapi_client.MlMetadataValue(string_value=self.owner),
-            "__ALL_META__":
+            ALL_META_PROPERTY_NAME:
                 openapi_client.MlMetadataValue(string_value=json.dumps(self.__dict__)),
         })
     return model_artifact

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -71,7 +71,7 @@ class TestMetedata(unittest.TestCase):
     artifact1 = ArtifactFixture(openapi_client.MlMetadataArtifact(
         uri="gs://uri",
         custom_properties={
-            r.WORKSPACE_PROPERTY_NAME:
+            metadata.WORKSPACE_PROPERTY_NAME:
             openapi_client.MlMetadataValue(string_value="ws1"),
         }
     ))
@@ -79,7 +79,7 @@ class TestMetedata(unittest.TestCase):
     artifact2 = ArtifactFixture(openapi_client.MlMetadataArtifact(
         uri="gs://uri",
         custom_properties={
-            r.RUN_PROPERTY_NAME:
+            metadata.RUN_PROPERTY_NAME:
             openapi_client.MlMetadataValue(string_value="run1"),
         }
     ))

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -61,24 +61,29 @@ class TestMetedata(unittest.TestCase):
             labels={"mylabel": "l1"}))
     assert model.id
 
-    def test_log_invalid_artifacts_should_fail(self):
-        r = metadata.Run(name="test run")
-        artifact1 = ArtifactFixture(openapi_client.MlMetadataArtifact(
-            uri="gs://uri",
-            custom_properites={
-                r.WORKSPACE_PROPERTY_NAME:
-                openapi_client.MlMetadataValue(string_value="ws1"),
-            }
-        ))
-        self.assertRaise(ValueError, r.log, artifact1)
-        artifact2 = ArtifactFixture(openapi_client.MlMetadataArtifact(
-            uri="gs://uri",
-            custom_properites={
-                r.RUN_PROPERTY_NAME:
-                openapi_client.MlMetadataValue(string_value="run1"),
-            }
-        ))
-        self.assertRaise(ValueError, r.log, artifact2)
+    self.assertTrue(len(ws1.list()) > 0)
+    self.assertTrue(len(ws1.list(metadata.Model.ARTIFACT_TYPE_NAME)) > 0)
+    self.assertTrue(len(ws1.list(metadata.Metrics.ARTIFACT_TYPE_NAME)) > 0)
+    self.assertTrue(len(ws1.list(metadata.DataSet.ARTIFACT_TYPE_NAME)) > 0)
+
+  def test_log_invalid_artifacts_should_fail(self):
+    r = metadata.Run(name="test run")
+    artifact1 = ArtifactFixture(openapi_client.MlMetadataArtifact(
+        uri="gs://uri",
+        custom_properties={
+            r.WORKSPACE_PROPERTY_NAME:
+            openapi_client.MlMetadataValue(string_value="ws1"),
+        }
+    ))
+    self.assertRaises(ValueError, r.log, artifact1)
+    artifact2 = ArtifactFixture(openapi_client.MlMetadataArtifact(
+        uri="gs://uri",
+        custom_properties={
+            r.RUN_PROPERTY_NAME:
+            openapi_client.MlMetadataValue(string_value="run1"),
+        }
+    ))
+    self.assertRaises(ValueError, r.log, artifact2)
 
 class ArtifactFixture(object):
   ARTIFACT_TYPE_NAME = "artifact_types/kubeflow.org/alpha/artifact_fixture"


### PR DESCRIPTION
This PR adds a method to list artifacts by type in a workspace, which can be later used to display new models trained in a Notebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/53)
<!-- Reviewable:end -->
