### PR TITLE
Uses correct env variable in frontend server and removes host from API server

### DIFF
--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -26,7 +26,7 @@ const {
   /** API service will listen to this host */
   METADATA_SERVICE_SERVICE_HOST = 'localhost',
   /** API service will listen to this port */
-  METADATA_SERVICE_SERVICE_PORT_HTTP = '8080'
+  METADATA_SERVICE_SERVICE_PORT = '8080'
 } = process.env;
 
 const app = express() as Application;
@@ -48,7 +48,7 @@ Usage: node server.js <static-dir> [port].
 const staticDir = path.resolve(process.argv[2]);
 
 const port = process.argv[3] || 3000;
-const apiServerAddress = `http://${METADATA_SERVICE_SERVICE_HOST}:${METADATA_SERVICE_SERVICE_PORT_HTTP}`;
+const apiServerAddress = `http://${METADATA_SERVICE_SERVICE_HOST}:${METADATA_SERVICE_SERVICE_PORT}`;
 
 const v1beta1Prefix = 'api/v1alpha1';
 

--- a/server/main.go
+++ b/server/main.go
@@ -36,7 +36,6 @@ import (
 )
 
 var (
-	host          = flag.String("host", "localhost", "Hostname to listen on.")
 	rpcPort       = flag.Int("rpc_port", 9090, "RPC serving port.")
 	httpPort      = flag.Int("http_port", 8080, "HTTP serving port.")
 	schemaRootDir = flag.String("schema_root_dir", "schema/alpha", "Root directory for the predefined schemas.")
@@ -107,7 +106,7 @@ func main() {
 	}
 	glog.Infof("Loaded predefined types: %v\n", predefinedTypes)
 
-	rpcEndpoint := fmt.Sprintf("%s:%d", *host, *rpcPort)
+	rpcEndpoint := fmt.Sprintf(":%d", *rpcPort)
 	rpcServer := grpc.NewServer()
 	pb.RegisterMetadataServiceServer(rpcServer, service)
 
@@ -129,7 +128,7 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	httpEndpoint := fmt.Sprintf("%s:%d", *host, *httpPort)
+	httpEndpoint := fmt.Sprintf(":%d", *httpPort)
 	glog.Infof("HTTP server listening on %s", httpEndpoint)
 	if err := http.ListenAndServe(httpEndpoint, mux); err != nil {
 		glog.Fatal(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

Setting `host` in `main.go` was preventing the server from being exposed on anything besides `localhost`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/68)
<!-- Reviewable:end -->
