### PR TITLE
Add homepage entry to allow serving from non-root folder

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
       "last 1 safari version"
     ]
   },
+  "homepage": "./",
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",


### PR DESCRIPTION
This enables the Metadata UI to be served from the `/metadata` virtual service path within a deployed Kubeflow cluster.

gcr.io/kubeflow-images-public/metadata-frontend:v0.1.7 has been pushed with this change in it.

Sample cluster at:
https://kubeflow-v-n00.endpoints.zhenghui-kubeflow-2.cloud.goog/_/metadata/#/artifacts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/80)
<!-- Reviewable:end -->
