### PR TITLE
in example notebook, uncomment installs; a few typo fixes

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
 # Python Library
 
-This directory conatins Python API for logging metadata of machine learning workflows to Kubeflow Metadata service.
+This directory contains the Python API for logging metadata of machine learning workflows to the Kubeflow Metadata service.
 
 ## Installation
 

--- a/sdk/python/demo.ipynb
+++ b/sdk/python/demo.ipynb
@@ -14,9 +14,9 @@
    "outputs": [],
    "source": [
     "# To use the latest publish `kfmd` library, you can run:\n",
-    "# !pip install kfmd\n",
+    "!pip install kfmd\n",
     "# Install other packages:\n",
-    "# !pip install pandas"
+    "!pip install pandas"
    ]
   },
   {
@@ -87,7 +87,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "An execution is create with id 5\n"
+      "An execution is created with id 5\n"
      ]
     }
    ],

--- a/sdk/python/kfmd/metadata.py
+++ b/sdk/python/kfmd/metadata.py
@@ -18,8 +18,8 @@ from kfmd import openapi_client
 from kfmd.openapi_client import Configuration, ApiClient, MetadataServiceApi
 
 """
-This module conatins Python API for logging metadata of machine learning
-workflows to Kubeflow Metadata service.
+This module contains the Python API for logging metadata of machine learning
+workflows to the Kubeflow Metadata service.
 """
 
 WORKSPACE_PROPERTY_NAME = '__kf_workspace__'


### PR DESCRIPTION
I noticed that KF v061 doesn't bundle kfmd or pandas in its default notebook image. (Though I think it should: https://github.com/kubeflow/kubeflow/issues/3848).
In the meantime, I think we should uncomment the installs, as this example is clearly meant to be run from the KF cluster.
Also fixed a few minor typos I noticed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/109)
<!-- Reviewable:end -->
