### PR TITLE
Owner Updates to add Kwasi / AP and remove Riley

### DIFF
--- a/frontend/OWNERS
+++ b/frontend/OWNERS
@@ -1,3 +1,4 @@
 approvers:
   - prodonjs
-  - rileyjbauer
+  - avdaredevil
+  - kwasi


### PR DESCRIPTION
## About
- Added AP, Kwasi (Since we're working on MLMD and foreseeable KFP tasks)
- Removed Riley (No longer in the project)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
NONE

### Meta
/area front-end
/area metadata
/priority p1
/assign @avdaredevil
/cc @prodonjs @kwasi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/143)
<!-- Reviewable:end -->
