### PR TITLE
Update Python SDK to use MLMD gRPC service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ dist
 .tox
 sdk/python/kubeflow/metadata/openapi_client/
 sdk/python/build
+.env

--- a/sdk/python/kubeflow/metadata/metadata.py
+++ b/sdk/python/kubeflow/metadata/metadata.py
@@ -78,12 +78,12 @@ class Workspace(object):
       backend_url_prefix {str} -- Deprecated. Please use 'store' parameter.
     """
     if backend_url_prefix:
-          raise ValueError("""'backend_url_prefix' is deprecated. Please set
-          Metadata.Store parameter to connect to the metadata gRPC service.""")
+      raise ValueError("""'backend_url_prefix' is deprecated. Please set
+        Metadata.Store parameter to connect to the metadata gRPC service.""")
     if name is None or type(name) != str:
-          raise ValueError("'name' must be set and in string type.")
+      raise ValueError("'name' must be set and in string type.")
     if not store or type(store) != Store:
-          raise ValueError("'store' must be set as metadata.Store")
+      raise ValueError("'store' must be set as metadata.Store")
     self.store = store.store
     self.name = name
     self.description = description
@@ -113,10 +113,10 @@ class Workspace(object):
       "id": artifact.id,
     }
     if artifact.custom_properties is not None:
-        if WORKSPACE_PROPERTY_NAME in artifact.custom_properties:
-          result["workspace"] = artifact.custom_properties[WORKSPACE_PROPERTY_NAME].string_value
-        if RUN_PROPERTY_NAME in artifact.custom_properties:
-          result["run"] = artifact.custom_properties[RUN_PROPERTY_NAME].string_value
+      if WORKSPACE_PROPERTY_NAME in artifact.custom_properties:
+        result["workspace"] = artifact.custom_properties[WORKSPACE_PROPERTY_NAME].string_value
+      if RUN_PROPERTY_NAME in artifact.custom_properties:
+        result["run"] = artifact.custom_properties[RUN_PROPERTY_NAME].string_value
     if not artifact.properties:
       return result
     for k,v in artifact.properties.items():
@@ -149,9 +149,9 @@ class Run(object):
       description {str} -- Optional description.
     """
     if workspace is None:
-          raise ValueError("'workspace' must be set.")
+        raise ValueError("'workspace' must be set.")
     if name is None or type(name) != str:
-          raise ValueError("'name' must be set and in string type.")
+        raise ValueError("'name' must be set and in string type.")
     self.workspace = workspace
     self.name = name
     self.description = description
@@ -177,9 +177,9 @@ class Execution(object):
     Returns an execution object for logging.
     """
     if workspace is None:
-          raise ValueError("'workspace' must be set.")
+        raise ValueError("'workspace' must be set.")
     if name is None or type(name) != str:
-          raise ValueError("'name' must be set and in string type.")
+        raise ValueError("'name' must be set and in string type.")
     self.id = None
     self.name = name
     self.workspace = workspace
@@ -193,19 +193,19 @@ class Execution(object):
 
   def serialized(self):
     properties={
-        "name": mlpb.Value(string_value=self.name),
-        "create_time": mlpb.Value(string_value=self.create_time),
-        "description": mlpb.Value(string_value=self.description),
+      "name": mlpb.Value(string_value=self.name),
+      "create_time": mlpb.Value(string_value=self.create_time),
+      "description": mlpb.Value(string_value=self.description),
     }
     _del_none_properties(properties)
 
     custom_properties = {}
     if self.workspace is not None:
       custom_properties[WORKSPACE_PROPERTY_NAME] = mlpb.Value(
-          string_value=self.workspace.name)
+        string_value=self.workspace.name)
     if self.run is not None:
       custom_properties[RUN_PROPERTY_NAME] = mlpb.Value(
-          string_value=self.run.name)
+        string_value=self.run.name)
     return mlpb.Execution(type_id=self._type_id, properties=properties,
       custom_properties=custom_properties)
 
@@ -221,7 +221,7 @@ class Execution(object):
     This method will set artifact.id.
     """
     if artifact is None:
-          raise ValueError("'artifact' must be set.")
+      raise ValueError("'artifact' must be set.")
     self._log(artifact)
     input_event = mlpb.Event(
       artifact_id=artifact.id,
@@ -266,15 +266,15 @@ class Execution(object):
     This method will set artifact.id.
     """
     if artifact is None:
-          raise ValueError("'artifact' must be set.")
+      raise ValueError("'artifact' must be set.")
     serialization = artifact.serialization()
     try:
-        serialization.type_id = self.workspace.store.get_artifact_type(
-          artifact.ARTIFACT_TYPE_NAME).id
+      serialization.type_id = self.workspace.store.get_artifact_type(
+        artifact.ARTIFACT_TYPE_NAME).id
     except Exception as e:
-        raise ValueError("invalid artifact type %s: exception %s", artifact.ARTIFACT_TYPE_NAME, e)
+      raise ValueError("invalid artifact type %s: exception %s", artifact.ARTIFACT_TYPE_NAME, e)
     if WORKSPACE_PROPERTY_NAME in serialization.custom_properties:
-          raise ValueError("custom_properties contains reserved key %s"
+      raise ValueError("custom_properties contains reserved key %s"
                            % WORKSPACE_PROPERTY_NAME)
     if RUN_PROPERTY_NAME in serialization.custom_properties:
       raise ValueError("custom_properties contains reserved key %s"
@@ -317,9 +317,9 @@ class DataSet(object):
     dataset.
     """
     if uri is None or type(uri) != str:
-          raise ValueError("'uri' must be set and in string type.")
+      raise ValueError("'uri' must be set and in string type.")
     if name is None or type(name) != str:
-          raise ValueError("'name' must be set and in string type.")
+      raise ValueError("'name' must be set and in string type.")
     self.workspace = workspace
     self.name = name
     self.description = description
@@ -333,17 +333,17 @@ class DataSet(object):
 
   def serialization(self):
     data_set_artifact = mlpb.Artifact(
-        uri=self.uri,
-        properties={
-            "name": mlpb.Value(string_value=self.name),
-            "create_time": mlpb.Value(string_value=self.create_time),
-            "description": mlpb.Value(string_value=self.description),
-            "query": mlpb.Value(string_value=self.query),
-            "version": mlpb.Value(string_value=self.version),
-            "owner": mlpb.Value(string_value=self.owner),
-            ALL_META_PROPERTY_NAME:
-                mlpb.Value(string_value=json.dumps(self.__dict__)),
-        })
+      uri=self.uri,
+      properties={
+          "name": mlpb.Value(string_value=self.name),
+          "create_time": mlpb.Value(string_value=self.create_time),
+          "description": mlpb.Value(string_value=self.description),
+          "query": mlpb.Value(string_value=self.query),
+          "version": mlpb.Value(string_value=self.version),
+          "owner": mlpb.Value(string_value=self.owner),
+          ALL_META_PROPERTY_NAME:
+              mlpb.Value(string_value=json.dumps(self.__dict__)),
+      })
     _del_none_properties(data_set_artifact.properties)
     return data_set_artifact
 
@@ -380,9 +380,9 @@ class Model(object):
     Addtional keyword arguments are saved as addtional properties of this model.
     """
     if uri is None or type(uri) != str:
-          raise ValueError("'uri' must be set and in string type.")
+      raise ValueError("'uri' must be set and in string type.")
     if name is None or type(name) != str:
-          raise ValueError("'name' must be set and in string type.")
+      raise ValueError("'name' must be set and in string type.")
     self.workspace = workspace
     self.name = name
     self.description = description
@@ -398,17 +398,17 @@ class Model(object):
 
   def serialization(self):
     model_artifact = mlpb.Artifact(
-        uri=self.uri,
-        properties={
-            "name": mlpb.Value(string_value=self.name),
-            "create_time": mlpb.Value(string_value=self.create_time),
-            "description": mlpb.Value(string_value=self.description),
-            "model_type": mlpb.Value(string_value=self.model_type),
-            "version": mlpb.Value(string_value=self.version),
-            "owner": mlpb.Value(string_value=self.owner),
-            ALL_META_PROPERTY_NAME:
-                mlpb.Value(string_value=json.dumps(self.__dict__)),
-        })
+      uri=self.uri,
+      properties={
+        "name": mlpb.Value(string_value=self.name),
+        "create_time": mlpb.Value(string_value=self.create_time),
+        "description": mlpb.Value(string_value=self.description),
+        "model_type": mlpb.Value(string_value=self.model_type),
+        "version": mlpb.Value(string_value=self.version),
+        "owner": mlpb.Value(string_value=self.owner),
+        ALL_META_PROPERTY_NAME:
+            mlpb.Value(string_value=json.dumps(self.__dict__)),
+    })
     _del_none_properties(model_artifact.properties)
     return model_artifact
 
@@ -470,26 +470,26 @@ class Metrics(object):
 
   def serialization(self):
     metrics_artifact = mlpb.Artifact(
-        uri=self.uri,
-        properties={
-            "name": mlpb.Value(string_value=self.name),
-            "create_time": mlpb.Value(string_value=self.create_time),
-            "description": mlpb.Value(string_value=self.description),
-            "metrics_type": mlpb.Value(string_value=self.metrics_type),
-            "data_set_id": mlpb.Value(string_value=self.data_set_id),
-            "model_id": mlpb.Value(string_value=self.model_id),
-            "owner": mlpb.Value(string_value=self.owner),
-            ALL_META_PROPERTY_NAME:
-                mlpb.Value(string_value=json.dumps(self.__dict__)),
+      uri=self.uri,
+      properties={
+        "name": mlpb.Value(string_value=self.name),
+        "create_time": mlpb.Value(string_value=self.create_time),
+        "description": mlpb.Value(string_value=self.description),
+        "metrics_type": mlpb.Value(string_value=self.metrics_type),
+        "data_set_id": mlpb.Value(string_value=self.data_set_id),
+        "model_id": mlpb.Value(string_value=self.model_id),
+        "owner": mlpb.Value(string_value=self.owner),
+        ALL_META_PROPERTY_NAME:
+          mlpb.Value(string_value=json.dumps(self.__dict__)),
         })
     _del_none_properties(metrics_artifact.properties)
     return metrics_artifact
 
 def get_rfc3339_time():
-      return datetime.datetime.utcnow().isoformat("T") + "Z"
+  return datetime.datetime.utcnow().isoformat("T") + "Z"
 
 def _del_none_properties(dict):
-      keys = [k for k in dict.keys()]
-      for k in keys:
-            if not any((dict[k].string_value, dict[k].int_value, dict[k].double_value)):
-                  del(dict[k])
+  keys = [k for k in dict.keys()]
+  for k in keys:
+    if not any((dict[k].string_value, dict[k].int_value, dict[k].double_value)):
+      del(dict[k])

--- a/sdk/python/kubeflow/metadata/metadata.py
+++ b/sdk/python/kubeflow/metadata/metadata.py
@@ -71,10 +71,11 @@ class Workspace(object):
                backend_url_prefix=None):
     """
     Args:
-      backend_url_prefix {str} -- deprecated.
+      store {Store} -- Required store object to connect to MLMD gRPC service.
       name {str} -- Required name for the workspace.
       description {str} -- Optional string for description of the workspace.
       labels {object} Optional key/value string pairs to label the workspace.
+      backend_url_prefix {str} -- Deprecated. Please use 'store' parameter.
     """
     if backend_url_prefix:
           raise ValueError("""'backend_url_prefix' is deprecated. Please set

--- a/sdk/python/kubeflow/metadata/metadata.py
+++ b/sdk/python/kubeflow/metadata/metadata.py
@@ -64,7 +64,7 @@ class Workspace(object):
   """
 
   def __init__(self,
-               store= None,
+               store=None,
                name=None,
                description=None,
                labels=None,

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -18,7 +18,7 @@ NAME = 'kubeflow-metadata'
 VERSION = '0.3.0'
 
 REQUIRES = [
-    'ml-metadata>=0.15.0',
+    'ml-metadata==0.15.0',
 ]
 
 setup(

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -15,10 +15,10 @@
 from setuptools import setup, find_packages
 
 NAME = 'kubeflow-metadata'
-VERSION = '0.2.0'
+VERSION = '0.3.0'
 
 REQUIRES = [
-    'ml-metadata>=0.15.0rc0',
+    'ml-metadata>=0.15.0',
 ]
 
 setup(

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -18,6 +18,7 @@ NAME = 'kubeflow-metadata'
 VERSION = '0.2.0'
 
 REQUIRES = [
+    'ml-metadata>=0.15.0rc0',
 ]
 
 setup(

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -142,6 +142,16 @@ class TestMetedata(unittest.TestCase):
                                description="a workspace for testing",
                                labels={"n1": "v1"})
 
+  def test_init_store_with_ssl_config(self):
+    # TODO: There is a type error in underlying ml_metadate library:
+    #   TypeError: expected certificate to be bytes, got <class 'str'>
+    # Fix this unit test once this bug is fixed.
+    with self.assertRaises(TypeError):
+      metadata.Store(grpc_host=GRPC_HOST,
+        grpc_port= GRPC_PORT,
+        root_certificates= b"cert",
+        private_key= b"private_key",
+        certificate_chain=b"chain")
 
 class ArtifactFixture(object):
   ARTIFACT_TYPE_NAME = "artifact_types/kubeflow.org/alpha/artifact_fixture"

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -2,11 +2,13 @@ import unittest
 from kubeflow.metadata import metadata
 from ml_metadata.proto import metadata_store_pb2 as mlpb
 
+GRPC_HOST = "127.0.0.1"
+GRPC_PORT = 8081
 
 class TestMetedata(unittest.TestCase):
 
   def test_log_metadata_successfully(self):
-    store = metadata.Store(grpc_host="127.0.0.1", grpc_port=8080)
+    store = metadata.Store(grpc_host=GRPC_HOST, grpc_port=GRPC_PORT)
     ws1 = metadata.Workspace(
         store=store,
         name="ws_1",
@@ -85,7 +87,7 @@ class TestMetedata(unittest.TestCase):
     assert len(all_events) == 3
 
   def test_log_invalid_artifacts_should_fail(self):
-    store = metadata.Store(grpc_host="127.0.0.1", grpc_port=8080)
+    store = metadata.Store(grpc_host=GRPC_HOST, grpc_port=GRPC_PORT)
     ws = metadata.Workspace(
     store=store,
     name="ws_1",
@@ -110,7 +112,7 @@ class TestMetedata(unittest.TestCase):
     self.assertRaises(ValueError, e.log_output, artifact2)
 
   def test_log_metadata_successfully_with_minimum_information(self):
-    store = metadata.Store(grpc_host="127.0.0.1",grpc_port=8080)
+    store = metadata.Store(grpc_host=GRPC_HOST,grpc_port=GRPC_PORT)
 
     ws1 = metadata.Workspace(store=store, name="ws_1")
 

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -95,14 +95,14 @@ class TestMetedata(unittest.TestCase):
     artifact1 = ArtifactFixture(
         mlpb.Artifact(uri="gs://uri",
                       custom_properties={
-                          metadata.WORKSPACE_PROPERTY_NAME:
+                          metadata._WORKSPACE_PROPERTY_NAME:
                               mlpb.Value(string_value="ws1"),
                       }))
     self.assertRaises(ValueError, e.log_input, artifact1)
     artifact2 = ArtifactFixture(
         mlpb.Artifact(uri="gs://uri",
                       custom_properties={
-                          metadata.RUN_PROPERTY_NAME:
+                          metadata._RUN_PROPERTY_NAME:
                               mlpb.Value(string_value="run1"),
                       }))
     self.assertRaises(ValueError, e.log_output, artifact2)

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -5,15 +5,15 @@ from ml_metadata.proto import metadata_store_pb2 as mlpb
 GRPC_HOST = "127.0.0.1"
 GRPC_PORT = 8081
 
+
 class TestMetedata(unittest.TestCase):
 
   def test_log_metadata_successfully(self):
     store = metadata.Store(grpc_host=GRPC_HOST, grpc_port=GRPC_PORT)
-    ws1 = metadata.Workspace(
-        store=store,
-        name="ws_1",
-        description="a workspace for testing",
-        labels={"n1": "v1"})
+    ws1 = metadata.Workspace(store=store,
+                             name="ws_1",
+                             description="a workspace for testing",
+                             labels={"n1": "v1"})
 
     r = metadata.Run(
         workspace=ws1,
@@ -30,19 +30,19 @@ class TestMetedata(unittest.TestCase):
     self.assertIsNotNone(e.id)
 
     data_set = e.log_input(
-        metadata.DataSet(
-            description="an example data",
-            name="mytable-dump",
-            owner="owner@my-company.org",
-            uri="file://path/to/dataset",
-            version="v1.0.0",
-            query="SELECT * FROM mytable"))
+        metadata.DataSet(description="an example data",
+                         name="mytable-dump",
+                         owner="owner@my-company.org",
+                         uri="file://path/to/dataset",
+                         version="v1.0.0",
+                         query="SELECT * FROM mytable"))
     self.assertIsNotNone(data_set.id)
 
     metrics = e.log_output(
         metadata.Metrics(
             name="MNIST-evaluation",
-            description="validating the MNIST model to recognize handwritten digits",
+            description=
+            "validating the MNIST model to recognize handwritten digits",
             owner="someone@kubeflow.org",
             uri="gcs://my-bucket/mnist-eval.csv",
             data_set_id="123",
@@ -53,23 +53,22 @@ class TestMetedata(unittest.TestCase):
     self.assertIsNotNone(metrics.id)
 
     model = e.log_output(
-        metadata.Model(
-            name="MNIST",
-            description="model to recognize handwritten digits",
-            owner="someone@kubeflow.org",
-            uri="gcs://my-bucket/mnist",
-            model_type="neural network",
-            training_framework={
-                "name": "tensorflow",
-                "version": "v1.0"
-            },
-            hyperparameters={
-                "learning_rate": 0.5,
-                "layers": [10, 3, 1],
-                "early_stop": True
-            },
-            version="v0.0.1",
-            labels={"mylabel": "l1"}))
+        metadata.Model(name="MNIST",
+                       description="model to recognize handwritten digits",
+                       owner="someone@kubeflow.org",
+                       uri="gcs://my-bucket/mnist",
+                       model_type="neural network",
+                       training_framework={
+                           "name": "tensorflow",
+                           "version": "v1.0"
+                       },
+                       hyperparameters={
+                           "learning_rate": 0.5,
+                           "layers": [10, 3, 1],
+                           "early_stop": True
+                       },
+                       version="v0.0.1",
+                       labels={"mylabel": "l1"}))
     self.assertIsNotNone(model.id)
 
     # Test listing artifacts in a workspace
@@ -88,31 +87,28 @@ class TestMetedata(unittest.TestCase):
 
   def test_log_invalid_artifacts_should_fail(self):
     store = metadata.Store(grpc_host=GRPC_HOST, grpc_port=GRPC_PORT)
-    ws = metadata.Workspace(
-    store=store,
-    name="ws_1",
-    description="a workspace for testing",
-    labels={"n1": "v1"})
+    ws = metadata.Workspace(store=store,
+                            name="ws_1",
+                            description="a workspace for testing",
+                            labels={"n1": "v1"})
     e = metadata.Execution(name="test execution", workspace=ws)
-    artifact1 = ArtifactFixture(mlpb.Artifact(
-        uri="gs://uri",
-        custom_properties={
-            metadata.WORKSPACE_PROPERTY_NAME:
-            mlpb.Value(string_value="ws1"),
-        }
-    ))
+    artifact1 = ArtifactFixture(
+        mlpb.Artifact(uri="gs://uri",
+                      custom_properties={
+                          metadata.WORKSPACE_PROPERTY_NAME:
+                              mlpb.Value(string_value="ws1"),
+                      }))
     self.assertRaises(ValueError, e.log_input, artifact1)
-    artifact2 = ArtifactFixture(mlpb.Artifact(
-        uri="gs://uri",
-        custom_properties={
-            metadata.RUN_PROPERTY_NAME:
-            mlpb.Value(string_value="run1"),
-        }
-    ))
+    artifact2 = ArtifactFixture(
+        mlpb.Artifact(uri="gs://uri",
+                      custom_properties={
+                          metadata.RUN_PROPERTY_NAME:
+                              mlpb.Value(string_value="run1"),
+                      }))
     self.assertRaises(ValueError, e.log_output, artifact2)
 
   def test_log_metadata_successfully_with_minimum_information(self):
-    store = metadata.Store(grpc_host=GRPC_HOST,grpc_port=GRPC_PORT)
+    store = metadata.Store(grpc_host=GRPC_HOST, grpc_port=GRPC_PORT)
 
     ws1 = metadata.Workspace(store=store, name="ws_1")
 
@@ -127,7 +123,7 @@ class TestMetedata(unittest.TestCase):
 
     metrics = e.log_output(
         metadata.Metrics(name="MNIST-evaluation",
-            uri="gcs://my-bucket/mnist-eval.csv"))
+                         uri="gcs://my-bucket/mnist-eval.csv"))
     self.assertIsNotNone(metrics.id)
 
     model = e.log_output(
@@ -136,26 +132,26 @@ class TestMetedata(unittest.TestCase):
 
   def test_invalid_workspace_should_fail(self):
     with self.assertRaises(ValueError):
-        ws1 = metadata.Workspace(
-                name="ws_1",
-                description="a workspace for testing",
-                labels={"n1": "v1"})
+      ws1 = metadata.Workspace(name="ws_1",
+                               description="a workspace for testing",
+                               labels={"n1": "v1"})
 
     with self.assertRaises(ValueError):
-        ws1 = metadata.Workspace(
-                store="127.1.0.1:8080",
-                name="ws_1",
-                description="a workspace for testing",
-                labels={"n1": "v1"})
+      ws1 = metadata.Workspace(store="127.1.0.1:8080",
+                               name="ws_1",
+                               description="a workspace for testing",
+                               labels={"n1": "v1"})
+
 
 class ArtifactFixture(object):
   ARTIFACT_TYPE_NAME = "artifact_types/kubeflow.org/alpha/artifact_fixture"
 
   def __init__(self, serialization_fixture=None):
-        self._fixture = serialization_fixture
+    self._fixture = serialization_fixture
 
   def serialization(self):
-      return self._fixture
+    return self._fixture
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/scripts/setup-services-run-tests.sh
+++ b/test/scripts/setup-services-run-tests.sh
@@ -127,12 +127,10 @@ done
 
 # Run CURL tests
 cd "${SRC_DIR}/test/e2e" && bash make_requests.sh
-# Run Python tests
-pip install pandas
-cd "${SRC_DIR}/sdk/python" && bash tests/run_tests.sh
 # Test demo notebook
 pip install jupyterlab
 pip install nbconvert
+pip install pandas
 cd "${SRC_DIR}/sdk/python" && \
   sed -i -e "s@metadata-service.kubeflow:8080@127.0.0.1:8080@" demo.ipynb && \
   python3 -m nbconvert --to notebook --execute demo.ipynb
@@ -144,6 +142,10 @@ echo "kubectl port-forward from $TARGET_GRPC_POD"
 kubectl -n $NAMESPACE port-forward $TARGET_GRPC_POD 8081:8080 &
 # Stream server logs.
 kubectl -n $NAMESPACE logs -f $TARGET_GRPC_POD &
+
+# Run Python tests
+pip install ml-metadata==0.15.0
+cd "${SRC_DIR}/sdk/python" && bash tests/run_tests.sh
 
 cd "${SRC_DIR}/watcher" && \
   go build -o main/main main/main.go && \


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to https://github.com/kubeflow/metadata/issues/155

This PR updates the python SDK.
- New `Store` class is introduced for connecting to MLMD gRPC service, which returns `ml_metadata.metadata_store.MetadataStore`.
- Old `backend_url` option for connecting to HTTP service is deprecated.
- Change E2E test to test python SDK with gRPC service.

It is a breaking change, since the way to connect backend service changes. I keep the `backend_url` as optional parameter to ask users to update their code if the `backend_url` is set.

I will update the demo notebook and upload the package to pypi in next PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/156)
<!-- Reviewable:end -->
