### PR TITLE
Add retry when connecting metadata store

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -49,7 +49,7 @@ var (
 	mySQLServicePort     = flag.Uint("mysql_service_port", 3306, "MySQL Service Port.")
 	mySQLServiceUser     = flag.String("mysql_service_user", "root", "MySQL Service Username.")
 	mySQLServicePassword = flag.String("mysql_service_password", "", "MySQL Service Password.")
-	retryNum             = flag.Int("retries_on_transaction_failure", 10, "Number of retries for exponentail backoff.")
+	retryNum             = flag.Int("retries_on_transaction_failure", 10, "Number of retries for exponential backoff.")
 	sqliteFilenameUri    = flag.String("sqlite_filename_uri", "mlmetadata", "Sqlite Filename URI")
 	sqliteConnMode       = flag.Int("sqlite_conn_mode", 3, "Sqlite Connection Mode. Supported options: 0(UNKNOWN), 1(READONLY), 2(READWRITE), 3(READWRITE_OPENCREATE)")
 )

--- a/server/main.go
+++ b/server/main.go
@@ -93,7 +93,7 @@ func mlmdStoreOrDie() *mlmetadata.Store {
 		if err == nil {
 			return store
 		}
-		sample := rand.Float64()*0.5 + 0.75 // randon sample from [0.75, 1.25]
+		sample := rand.Float64()*0.5 + 0.75 // random sample from [0.75, 1.25]
 		backoff := time.Millisecond * time.Duration(1000*math.Pow(2, float64(r))*sample)
 		glog.Errorf("Failed to create ML Metadata Store: %v.\nRetry %d/%d.\nSleep %v", err, r+1, *retryNum, backoff)
 		time.Sleep(backoff)


### PR DESCRIPTION
related to #138 

Add retries when failed to connected to MLMD store. `i`th retry will wait ~`2^(i-1)` seconds.

Tested it on a KF cluster and the `metadata-service` has 0 crash of 2 replicas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/157)
<!-- Reviewable:end -->
