### PR TITLE
Pin ml-metadata dependency to v0.14.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,7 +92,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 go_repository(
     name = "google_ml_metadata",
-    commit = "77b3620fd3e065821cc9b692390d23f8475c9bb2",
+    commit = "3a5c41c661e65fcde6f8fa8ea1945a03273e99a8",
     importpath = "github.com/google/ml-metadata",
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin mlmd to https://github.com/google/ml-metadata/releases/tag/v0.14.0
So that the HTTP server has the save version as the gRPC service.

related to #138

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/158)
<!-- Reviewable:end -->
