### PR TITLE
Add arm64 support for metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # The docker build flags are
 # BASE_IMG: base image that has Go and Bazel installed.
 # EXTRA_BAZEL_ARGS: extra arguments of bazel build. Set it to
-# --host_javabase=@local_jdk//:jdk when build on power.
+# --host_javabase=@local_jdk//:jdk when build on power or arm64 machines.
 # OUTPUT_DIR: the platform name that Bazel used to ouput the executable.
 
 ARG BASE_IMG=gcr.io/kubeflow-images-public/metadata-base

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ mlmd-proto:
 metadata-docker-image:
 	docker build -t gcr.io/kubeflow-images-public/metadata .
 
+metadata-docker-image-aarch64:
+	docker build -t metadata-base-aarch64:latest -f ./dockerfiles/Dockerfile-linux-base.aarch64 . && \
+	docker build -t kubeflow-images-public/metadata --build-arg BASE_IMG=metadata-base-aarch64:latest --build-arg OUTPUT_DIR=linux_arm64_stripped .
+
 swagger-py-client:
 	mkdir -p /tmp/swagger
 	wget http://central.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.1/openapi-generator-cli-4.0.1.jar -O /tmp/swagger/swagger-codegen-cli.jar && \

--- a/dockerfiles/Dockerfile-linux-base.aarch64
+++ b/dockerfiles/Dockerfile-linux-base.aarch64
@@ -1,0 +1,22 @@
+# This file builds the base image for metadata backend server on arm64.
+
+FROM golang:1.12
+
+RUN apt-get update && apt-get -y install cmake unzip patch wget && apt-get clean
+
+RUN apt-get install -y unzip build-essential python openjdk-11-jdk protobuf-compiler zip g++ zlib1g-dev && \
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64 && \
+    export JRE_HOME=${JAVA_HOME}/jre && \
+    export CLASSPATH=.:${JAVA_HOME}/lib:${JRE_HOME}/lib && \
+    export PATH=${JAVA_HOME}/bin:$PATH && \
+    mkdir /tmp/bazel && \
+    cd /tmp/bazel && \
+    wget https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-dist.zip && \
+    unzip bazel-0.24.1-dist.zip && \
+    env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" bash ./compile.sh && \
+    mkdir /root/bin && \
+    cp output/bazel /root/bin/;
+
+ENV PATH=/root/bin:${PATH}
+
+CMD ["bash"]


### PR DESCRIPTION
Referencing #96 and [kubeflow/issue#2237](https://github.com/kubeflow/kubeflow/issues/2337), add arm64 support for metadata. Have tested the docker image building on both arm64 and x86_64 machines.

Signed-off-by: Henry Wang <<henry.wang@arm.com>>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/164)
<!-- Reviewable:end -->
