### PR TITLE
Python SDK improvements

### DIFF
--- a/sdk/python/kubeflow/metadata/metadata.py
+++ b/sdk/python/kubeflow/metadata/metadata.py
@@ -43,7 +43,7 @@ class Artifact(ABC):
     pass
 
   @staticmethod
-  def isDuplicated(a: mlpb.Artifact, b: mlpb.Artifact):
+  def is_duplicated(a: mlpb.Artifact, b: mlpb.Artifact):
     '''Checks if two artifacts are duplicated.
 
     The artifacts may be considered duplication even if not all the fields are
@@ -52,7 +52,6 @@ class Artifact(ABC):
 
     Returns:
       True or False for duplication.
-      NotImplemented is same as False.
     '''
     return NotImplemented
 
@@ -308,6 +307,7 @@ class Execution(object):
       raise ValueError("invalid artifact type %s: exception %s",
                        artifact.ARTIFACT_TYPE_NAME, e)
 
+    # if id is set, then this artifact is already saved in database.
     if artifact.id is not None:
       self._check_artifact_id(artifact.id)
       return artifact
@@ -331,7 +331,7 @@ class Execution(object):
     pbs = _retry(
         lambda: self.workspace.store.get_artifacts_by_uri(artifact.uri))
     for pb in pbs:
-      if artifact.isDuplicated(ser, pb):
+      if artifact.is_duplicated(ser, pb):
         artifact.id = pb.id
         return artifact
 
@@ -436,11 +436,11 @@ class DataSet(Artifact):
     return data_set_artifact
 
   @staticmethod
-  def isDuplicated(a, b):
+  def is_duplicated(a, b):
     ap = a.properties
     bp = b.properties
-    return a.uri == b.uri and ap["name"] == bp["name"] and ap["version"] == bp[
-        "version"] and a.custom_properties[
+    return a.type_id == b.type_id and a.uri == b.uri and ap["name"] == bp[
+        "name"] and ap["version"] == bp["version"] and a.custom_properties[
             _WORKSPACE_PROPERTY_NAME] == b.custom_properties[
                 _WORKSPACE_PROPERTY_NAME]
 
@@ -548,11 +548,11 @@ class Model(Artifact):
     return model_artifact
 
   @staticmethod
-  def isDuplicated(a, b):
+  def is_duplicated(a, b):
     ap = a.properties
     bp = b.properties
-    return a.uri == b.uri and ap["name"] == bp["name"] and ap["version"] == bp[
-        "version"] and a.custom_properties[
+    return a.type_id == b.type_id and a.uri == b.uri and ap["name"] == bp[
+        "name"] and ap["version"] == bp["version"] and a.custom_properties[
             _WORKSPACE_PROPERTY_NAME] == b.custom_properties[
                 _WORKSPACE_PROPERTY_NAME]
 

--- a/sdk/python/kubeflow/metadata/metadata.py
+++ b/sdk/python/kubeflow/metadata/metadata.py
@@ -240,6 +240,13 @@ class Execution(object):
         lambda: self.workspace.store.put_executions([self.serialized()]))
     self.id = response[0]
 
+  def __repr__(self):
+    field_names = self.__dict__.keys()
+    fields_str = ", ".join(
+        "{}={!r}".format(name, getattr(self, name)) for name in field_names)
+    return "{0.__class__.__module__}.{0.__class__.__qualname__}({1})".format(
+        self, fields_str)
+
   def serialized(self):
     properties = {
         "name": mlpb.Value(string_value=self.name),
@@ -412,6 +419,14 @@ class DataSet(Artifact):
     self.labels = labels
     self.id = None
     self.create_time = _get_rfc3339_time()
+    self.kwargs = kwargs
+
+  def __repr__(self):
+    field_names = self.__dict__.keys()
+    fields_str = ", ".join(
+        "{}={!r}".format(name, getattr(self, name)) for name in field_names)
+    return "{0.__class__.__module__}.{0.__class__.__qualname__}({1})".format(
+        self, fields_str)
 
   def serialization(self):
     data_set_artifact = mlpb.Artifact(
@@ -524,6 +539,14 @@ class Model(Artifact):
     self.labels = labels
     self.id = None
     self.create_time = _get_rfc3339_time()
+    self.kwargs = kwargs
+
+  def __repr__(self):
+    field_names = self.__dict__.keys()
+    fields_str = ", ".join(
+        "{}={!r}".format(name, getattr(self, name)) for name in field_names)
+    return "{0.__class__.__module__}.{0.__class__.__qualname__}({1})".format(
+        self, fields_str)
 
   def serialization(self):
     model_artifact = mlpb.Artifact(
@@ -636,6 +659,14 @@ class Metrics(Artifact):
     self.labels = labels
     self.id = None
     self.create_time = _get_rfc3339_time()
+    self.kwargs = kwargs
+
+  def __repr__(self):
+    field_names = self.__dict__.keys()
+    fields_str = ", ".join(
+        "{}={!r}".format(name, getattr(self, name)) for name in field_names)
+    return "{0.__class__.__module__}.{0.__class__.__qualname__}({1})".format(
+        self, fields_str)
 
   def serialization(self):
     metrics_artifact = mlpb.Artifact(

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -19,6 +19,7 @@ VERSION = '0.3.0'
 
 REQUIRES = [
     'ml-metadata==0.15.0',
+    'retry'
 ]
 
 setup(

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -19,7 +19,7 @@ VERSION = '0.3.0'
 
 REQUIRES = [
     'ml-metadata==0.15.0',
-    'retry'
+    'retrying'
 ]
 
 setup(

--- a/sdk/python/tests/run_tests.sh
+++ b/sdk/python/tests/run_tests.sh
@@ -14,7 +14,12 @@
 # limitations under the License.
 
 cd $(dirname $0)/..
+rm -rf .testing-env
+python3 -m venv .testing-env && \
+source .testing-env/bin/activate && \
+python3 -m pip install -U pip
 python3 -m pip install pytest
 # install local kubeflow.metadata package
 python3 -m pip install -e .
 python3 -m pytest tests/test.py
+rm -rf .testing-env

--- a/sdk/python/tests/run_tests.sh
+++ b/sdk/python/tests/run_tests.sh
@@ -13,5 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd $(dirname $0)/../kubeflow/metadata
-python3 -m unittest discover --verbose --start-dir ../../tests --top-level-directory=../..
+cd $(dirname $0)/..
+python3 -m pip install pytest
+# install local kubeflow.metadata package
+python3 -m pip install -e .
+python3 -m pytest tests/test.py

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -72,7 +72,7 @@ class TestMetedata(unittest.TestCase):
                            "layers": [10, 3, 1],
                            "early_stop": True
                        },
-                       version="v0.0.1",
+                       version=str(uuid.uuid4()),
                        labels={"mylabel": "l1"}))
     self.assertIsNotNone(model.id)
 
@@ -84,11 +84,11 @@ class TestMetedata(unittest.TestCase):
 
     # Test lineage tracking.
     output_events = ws1.store.get_events_by_artifact_ids([model.id])
-    assert len(output_events) == 1
+    self.assertEqual(len(output_events), 1)
     execution_id = output_events[0].execution_id
-    assert execution_id == e.id
+    self.assertEqual(execution_id, e.id)
     all_events = ws1.store.get_events_by_execution_ids([execution_id])
-    assert len(all_events) == 3
+    self.assertEqual(len(all_events), 3)
 
   def test_log_invalid_artifacts_should_fail(self):
     store = metadata.Store(grpc_host=GRPC_HOST, grpc_port=GRPC_PORT)
@@ -174,7 +174,7 @@ class TestMetedata(unittest.TestCase):
                      private_key=b"private_key",
                      certificate_chain=b"chain")
 
-  def test_artifact_dedupe(self):
+  def test_artifact_deduplication(self):
     store = metadata.Store(grpc_host=GRPC_HOST, grpc_port=GRPC_PORT)
     ws1 = metadata.Workspace(store=store, name="workspace_one")
     ws2 = metadata.Workspace(store=store, name="workspace_two")

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -161,7 +161,7 @@ class TestMetedata(unittest.TestCase):
     model_id = model.id
     # ID should not change after logging twice.
     e.log_output(model)
-    self.assertEqual(metrics_id, metrics.id)
+    self.assertEqual(model_id, model.id)
 
   def test_invalid_workspace_should_fail(self):
     with self.assertRaises(ValueError):

--- a/sdk/python/tests/test.py
+++ b/sdk/python/tests/test.py
@@ -196,8 +196,24 @@ class TestMetedata(unittest.TestCase):
     e.log_output(model)
     self.assertIsNotNone(model.id)
     e2.log_output(model2)
-    self.assertIsNotNone(model.id)
+    self.assertIsNotNone(model2.id)
     self.assertEqual(model.id, model2.id)
+
+  def test_is_duplicated_methods(self):
+    for cls in [metadata.Model, metadata.DataSet]:
+      m = mlpb_artifact(1, "gcs://123", "ws1", "name1", "v1")
+      m1 = mlpb_artifact(1, "gcs://123", "ws1", "name1", "v1")
+      self.assertTrue(cls.is_duplicated(m, m1))
+      m2 = mlpb_artifact(1, "gcs://123", "ws1", "name1")
+      self.assertFalse(cls.is_duplicated(m, m2))
+      m3 = mlpb_artifact(1, "gcs://123", "ws1", "name2", "v1")
+      self.assertFalse(cls.is_duplicated(m, m3))
+      m4 = mlpb_artifact(1, "gcs://123", "ws2", "name1", "v1")
+      self.assertFalse(cls.is_duplicated(m, m4))
+      m5 = mlpb_artifact(1, "gcs://1234", "ws1", "name1", "v1")
+      self.assertFalse(cls.is_duplicated(m, m5))
+      m6 = mlpb_artifact(2, "gcs://123", "ws1", "name1", "v1")
+      self.assertFalse(cls.is_duplicated(m, m6))
 
 
 class CheckMetadataStore(object):
@@ -218,6 +234,21 @@ class ArtifactFixture(object):
 
   def serialization(self):
     return self._fixture
+
+
+def mlpb_artifact(type_id, uri, workspace, name=None, version=None):
+  properties = {}
+  if name:
+    properties["name"] = mlpb.Value(string_value=name)
+  if version:
+    properties["version"] = mlpb.Value(string_value=version)
+  return mlpb.Artifact(uri=uri,
+                       type_id=type_id,
+                       properties=properties,
+                       custom_properties={
+                           metadata._WORKSPACE_PROPERTY_NAME:
+                               mlpb.Value(string_value=workspace),
+                       })
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR improves current Python SDK:
- Adds retries to all outbound gRPC calls.
- Handles the case of logging the same artifact multiple times:
  - Case 1: the artifact already has a ID assigned. It means this artifact was saved before, then no need to save the data again.
  - Case 2: new artifact doesn't have ID, but can be considered as duplication of some artifact in the DB. For example, a model with save `name`, `version` and `uri`. An artifact class is asked to have a optional `is_duplicated` method to determine the case.
- Introduces python ABC for abstract Artifact, which formally states the protocol used before.
- add `__repr__` to better print out artifact objects.

Testing:
- More tests are added.
- Rewrite the test setup to start tests from a virtual env.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/167)
<!-- Reviewable:end -->
