### PR TITLE
Initial pass of fetching data from gRPC backend and click to update

### DIFF
--- a/frontend/src/components/LineageCard.tsx
+++ b/frontend/src/components/LineageCard.tsx
@@ -20,9 +20,7 @@ export class LineageCard extends React.Component<LineageCardProps> {
     const listCardRows = () => rows.map((r, i) =>
       <LineageCardRow
         key={i}
-        artifact={r.artifact}
-        title={r.title}
-        description={r.desc}
+        resource={r.resource}
         leftAffordance={!!r.prev}
         rightAffordance={!!r.next}
         isLastRow={i === rows.length-1}

--- a/frontend/src/components/LineageCard.tsx
+++ b/frontend/src/components/LineageCard.tsx
@@ -20,6 +20,7 @@ export class LineageCard extends React.Component<LineageCardProps> {
     const listCardRows = () => rows.map((r, i) =>
       <LineageCardRow
         key={i}
+        artifact={r.artifact}
         title={r.title}
         description={r.desc}
         leftAffordance={!!r.prev}

--- a/frontend/src/components/LineageCardRow.tsx
+++ b/frontend/src/components/LineageCardRow.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import './LineageCardRow.css';
-import {
-  Artifact,
-  Value
-} from "../generated/src/apis/metadata/metadata_store_pb";
-import {ArtifactProperties} from "../lib/Api";
+import {Artifact} from "../generated/src/apis/metadata/metadata_store_pb";
 
 interface LineageCardRowProps {
   title: string;
@@ -13,6 +9,7 @@ interface LineageCardRowProps {
   rightAffordance: boolean;
   hideRadio: boolean;
   isLastRow: boolean;
+  artifact?: Artifact;
   setLineageViewTarget?(artifact: Artifact): void
 }
 
@@ -49,17 +46,8 @@ export class LineageCardRow extends React.Component<LineageCardRowProps> {
     return <div className='noRadio' />;
   }
 
-  private get artifact(): Artifact {
-    // TODO: Return this.props.artifact once available.
-    const mockArtifact = new Artifact();
-    const nameValue = new Value();
-    nameValue.setStringValue(this.props.title);
-    mockArtifact.getPropertiesMap().set(ArtifactProperties.NAME, nameValue);
-    return mockArtifact
-  }
-
   private handleClick() {
-    if (!this.props.setLineageViewTarget) return;
-    this.props.setLineageViewTarget(this.artifact);
+    if (!this.props.setLineageViewTarget || !this.props.artifact) return;
+    this.props.setLineageViewTarget(this.props.artifact);
   }
 }

--- a/frontend/src/components/LineageCardRow.tsx
+++ b/frontend/src/components/LineageCardRow.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import './LineageCardRow.css';
-import {Artifact} from "../generated/src/apis/metadata/metadata_store_pb";
+import {
+  Artifact,
+} from "../generated/src/apis/metadata/metadata_store_pb";
+import {LineageResource} from "./LineageTypes";
+import {
+ getResourceDescription, getResourceName,
+} from "../lib/Utils";
 
 interface LineageCardRowProps {
-  title: string;
-  description?: string;
   leftAffordance: boolean;
   rightAffordance: boolean;
   hideRadio: boolean;
   isLastRow: boolean;
-  artifact?: Artifact;
+  resource: LineageResource
   setLineageViewTarget?(artifact: Artifact): void
 }
 
@@ -25,14 +29,16 @@ export class LineageCardRow extends React.Component<LineageCardRowProps> {
     this.props.rightAffordance && affItems.push(<div className='edgeRight' key={'edgeRight'} />);
     return affItems;
   }
+
   public render(): JSX.Element {
-    const {title, description, isLastRow} = this.props;
+    const {isLastRow} = this.props;
+
     return (
       <div className={`cardRow ${isLastRow?'lastRow':''}`}>
         {this.checkRadio()}
         <footer>
-          <p className='rowTitle'>{title}</p>
-          <p className='rowDesc'>{description}</p>
+          <p className='rowTitle'>{getResourceName(this.props.resource)}</p>
+          <p className='rowDesc'>{getResourceDescription(this.props.resource)}</p>
         </footer>
         {this.checkEdgeAffordances()}
       </div>
@@ -47,7 +53,7 @@ export class LineageCardRow extends React.Component<LineageCardRowProps> {
   }
 
   private handleClick() {
-    if (!this.props.setLineageViewTarget || !this.props.artifact) return;
-    this.props.setLineageViewTarget(this.props.artifact);
+    if (!this.props.setLineageViewTarget || !(this.props.resource instanceof Artifact)) return;
+    this.props.setLineageViewTarget(this.props.resource);
   }
 }

--- a/frontend/src/components/LineageTypes.ts
+++ b/frontend/src/components/LineageTypes.ts
@@ -1,6 +1,10 @@
 /**
  * This file provides common types used by the Lineage Explorer components
  */
+import {
+    Artifact,
+    Execution
+} from "../generated/src/apis/metadata/metadata_store_pb";
 
 export type LineageCardType = 'artifact' | 'execution';
 export interface LineageRow {
@@ -8,5 +12,7 @@ export interface LineageRow {
     desc?: string;
     prev?: boolean;
     next?: boolean;
+    artifact?: Artifact,
+    execution?: Execution,
 }
 export const DEFAULT_LINEAGE_CARD_TYPE = 'artifact' as LineageCardType;

--- a/frontend/src/components/LineageTypes.ts
+++ b/frontend/src/components/LineageTypes.ts
@@ -8,11 +8,11 @@ import {
 
 export type LineageCardType = 'artifact' | 'execution';
 export interface LineageRow {
-    title: string;
-    desc?: string;
     prev?: boolean;
     next?: boolean;
-    artifact?: Artifact,
-    execution?: Execution,
+    resource: LineageResource;
 }
+
+export type LineageResource = Artifact | Execution;
+
 export const DEFAULT_LINEAGE_CARD_TYPE = 'artifact' as LineageCardType;

--- a/frontend/src/lib/Utils.tsx
+++ b/frontend/src/lib/Utils.tsx
@@ -214,9 +214,8 @@ function getExecutionName(execution: Execution): string {
 export function getResourceName(resource: LineageResource): string {
   if (resource instanceof Artifact) {
     return getArtifactName(resource);
-  } else {
-    return getExecutionName(resource);
   }
+  return getExecutionName(resource);
 }
 
 export function getResourceDescription(resource: LineageResource): string {

--- a/frontend/src/lib/Utils.tsx
+++ b/frontend/src/lib/Utils.tsx
@@ -18,9 +18,16 @@ import * as React from 'react';
 import {isFunction} from 'lodash';
 import {Column, css as customTableCss, CustomTableRow, ExpandState, Row} from '../components/CustomTable';
 import {classes} from 'typestyle';
-import {ListRequest} from './Api';
+import {
+  ArtifactCustomProperties,
+  ArtifactProperties,
+  ExecutionCustomProperties,
+  ExecutionProperties,
+  ListRequest
+} from './Api';
 import {padding} from '../Css';
 import {Artifact, Execution, Value} from "../generated/src/apis/metadata/metadata_store_pb";
+import {LineageResource} from "../components/LineageTypes";
 
 export const logger = {
   error: (...args: any[]) => {
@@ -194,4 +201,32 @@ export function getExpandedRow(expandedRows: Map<number, Row[]>, columns: Column
       </div>
     );
   }
+}
+
+function getArtifactName(artifact: Artifact): string {
+  return String(getResourceProperty(artifact, ArtifactProperties.NAME))
+}
+
+function getExecutionName(execution: Execution): string {
+  return String(getResourceProperty(execution, ExecutionProperties.NAME))
+}
+
+export function getResourceName(resource: LineageResource): string {
+  if (resource instanceof Artifact) {
+    return getArtifactName(resource);
+  } else {
+    return getExecutionName(resource);
+  }
+}
+
+export function getResourceDescription(resource: LineageResource): string {
+  let description;
+  if (resource instanceof Artifact) {
+    description = getResourceProperty(resource, ArtifactProperties.PIPELINE_NAME)
+      || getResourceProperty(resource, ArtifactCustomProperties.WORKSPACE, true);
+  } else {
+    description = getResourceProperty(resource, ExecutionProperties.PIPELINE_NAME)
+      || getResourceProperty(resource, ExecutionCustomProperties.WORKSPACE, true);
+  }
+  return String(description) || '';
 }

--- a/frontend/src/pages/ArtifactDetails.test.tsx
+++ b/frontend/src/pages/ArtifactDetails.test.tsx
@@ -6,7 +6,12 @@ import {Api} from '../lib/Api';
 import * as TestUtils from '../TestUtils'
 import {RouteParams} from '../components/Router';
 import {testModel} from '../TestUtils';
-import {GetArtifactsByIDResponse} from '../generated/src/apis/metadata/metadata_store_service_pb';
+import {
+  GetArtifactsByIDResponse,
+  GetEventsByArtifactIDsResponse,
+  GetExecutionsByIDResponse,
+  GetExecutionsResponse
+} from '../generated/src/apis/metadata/metadata_store_service_pb';
 
 describe('ArtifactDetails', () => {
   let tree: ShallowWrapper | ReactWrapper;
@@ -14,8 +19,19 @@ describe('ArtifactDetails', () => {
   const updateToolbarSpy = jest.fn();
   const historyPushSpy = jest.fn();
   const mockGetArtifact = jest.spyOn(Api.getInstance().metadataStoreService, 'getArtifactsByID');
+  const mockGetEventsByArtifactIDs =
+    jest.spyOn(Api.getInstance().metadataStoreService, 'getEventsByArtifactIDs');
+  const mockGetExecutions =
+    jest.spyOn(Api.getInstance().metadataStoreService, 'getExecutions');
+  const mockGetExecutionsByID =
+    jest.spyOn(Api.getInstance().metadataStoreService, 'getExecutionsByID');
+
   const fakeGetArtifactByIDResponse = new GetArtifactsByIDResponse();
   fakeGetArtifactByIDResponse.addArtifacts(testModel);
+
+  const fakeGetEventsByArtifactIDsResponse = new GetEventsByArtifactIDsResponse();
+  const fakeGetExecutions = new GetExecutionsResponse();
+  const fakeGetExecutionsByIDResponse = new GetExecutionsByIDResponse();
 
   const MODEL_TYPE = 'kubeflow.org/alpha/model';
   const FAKE_MODEL_ID = '1';
@@ -51,6 +67,11 @@ describe('ArtifactDetails', () => {
 
   it('Renders with a Model Artifact and updates the page title', async () => {
     mockGetArtifact.mockResolvedValue(fakeGetArtifactByIDResponse);
+    mockGetEventsByArtifactIDs.mockResolvedValue(
+      fakeGetEventsByArtifactIDsResponse);
+    mockGetExecutions.mockResolvedValue(fakeGetExecutions);
+    mockGetExecutionsByID.mockResolvedValue(fakeGetExecutionsByIDResponse);
+
     tree = TestUtils.mountWithRouter(<ArtifactDetails {...generateProps()} />);
 
     await mockGetArtifact;

--- a/frontend/src/pages/ArtifactDetails.test.tsx
+++ b/frontend/src/pages/ArtifactDetails.test.tsx
@@ -9,6 +9,7 @@ import {testModel} from '../TestUtils';
 import {
   GetArtifactsByIDResponse,
   GetEventsByArtifactIDsResponse,
+  GetEventsByExecutionIDsResponse,
   GetExecutionsByIDResponse,
   GetExecutionsResponse
 } from '../generated/src/apis/metadata/metadata_store_service_pb';
@@ -25,6 +26,8 @@ describe('ArtifactDetails', () => {
     jest.spyOn(Api.getInstance().metadataStoreService, 'getExecutions');
   const mockGetExecutionsByID =
     jest.spyOn(Api.getInstance().metadataStoreService, 'getExecutionsByID');
+  const mockGetEventsByExecutionIDs =
+    jest.spyOn(Api.getInstance().metadataStoreService, 'getEventsByExecutionIDs');
 
   const fakeGetArtifactByIDResponse = new GetArtifactsByIDResponse();
   fakeGetArtifactByIDResponse.addArtifacts(testModel);
@@ -32,6 +35,7 @@ describe('ArtifactDetails', () => {
   const fakeGetEventsByArtifactIDsResponse = new GetEventsByArtifactIDsResponse();
   const fakeGetExecutions = new GetExecutionsResponse();
   const fakeGetExecutionsByIDResponse = new GetExecutionsByIDResponse();
+  const fakeGetEventsByExecutionIDsResponse = new GetEventsByExecutionIDsResponse();
 
   const MODEL_TYPE = 'kubeflow.org/alpha/model';
   const FAKE_MODEL_ID = '1';
@@ -67,10 +71,10 @@ describe('ArtifactDetails', () => {
 
   it('Renders with a Model Artifact and updates the page title', async () => {
     mockGetArtifact.mockResolvedValue(fakeGetArtifactByIDResponse);
-    mockGetEventsByArtifactIDs.mockResolvedValue(
-      fakeGetEventsByArtifactIDsResponse);
+    mockGetEventsByArtifactIDs.mockResolvedValue(fakeGetEventsByArtifactIDsResponse);
     mockGetExecutions.mockResolvedValue(fakeGetExecutions);
-    mockGetExecutionsByID.mockResolvedValue(fakeGetExecutionsByIDResponse);
+    mockGetExecutionsByID.mockResolvedValue(fakeGetExecutionsByIDResponse)
+    mockGetEventsByExecutionIDs.mockResolvedValue(fakeGetEventsByExecutionIDsResponse);
 
     tree = TestUtils.mountWithRouter(<ArtifactDetails {...generateProps()} />);
 

--- a/frontend/src/pages/ArtifactDetails.tsx
+++ b/frontend/src/pages/ArtifactDetails.tsx
@@ -52,8 +52,7 @@ export default class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
   constructor(props: {}) {
     super(props);
     this.state = {
-      // TODO: Remove before submission
-      selectedTab: ArtifactDetailsTab.LINEAGE_EXPLORER
+      selectedTab: ArtifactDetailsTab.OVERVIEW
     };
     this.load = this.load.bind(this);
   }

--- a/frontend/src/pages/ArtifactDetails.tsx
+++ b/frontend/src/pages/ArtifactDetails.tsx
@@ -52,7 +52,8 @@ export default class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
   constructor(props: {}) {
     super(props);
     this.state = {
-      selectedTab: ArtifactDetailsTab.OVERVIEW
+      // TODO: Remove before submission
+      selectedTab: ArtifactDetailsTab.LINEAGE_EXPLORER
     };
     this.load = this.load.bind(this);
   }

--- a/frontend/src/pages/LineageView.tsx
+++ b/frontend/src/pages/LineageView.tsx
@@ -18,29 +18,25 @@
 import * as React from 'react';
 import {classes} from 'typestyle';
 import {commonCss} from '../Css';
-import {Api, ArtifactProperties, ExecutionProperties} from '../lib/Api';
+import {Api} from '../lib/Api';
 import {LineageCardColumn, CardDetails} from '../components/LineageCardColumn';
 import {LineageActionBar} from '../components/LineageActionBar';
-import {
-  Artifact, Event, Execution
-} from '../generated/src/apis/metadata/metadata_store_pb';
-import {getResourceProperty} from '../lib/Utils';
+import {Artifact, Event, Execution} from '../generated/src/apis/metadata/metadata_store_pb';
 import {RefObject} from 'react';
 import {
   GetArtifactsByIDRequest,
-  GetEventsByArtifactIDsRequest, GetEventsByExecutionIDsRequest,
+  GetEventsByArtifactIDsRequest,
+  GetEventsByExecutionIDsRequest,
   GetExecutionsByIDRequest
 } from '../generated/src/apis/metadata/metadata_store_service_pb';
-import {MetadataStoreServicePromiseClient} from "../generated/src/apis/metadata/metadata_store_service_grpc_web_pb";
+import {
+  MetadataStoreServicePromiseClient
+} from "../generated/src/apis/metadata/metadata_store_service_grpc_web_pb";
 
-// TODO: I was having trouble getting these enum values to work so I made this hack.
-// https://github.com/google/ml-metadata/blob/master/ml_metadata/proto/metadata_store.proto#L108
-// 1 = ml_metadata.Event.DECLARED_OUTPUT
-// 2 = ml_metadata.Event.DECLARED_INPUT
-// 3 = ml_metadata.Event.INPUT
-// 4 = ml_metadata.Event.OUTPUT
-const isInputEvent = (event: Event) => [2, 3].includes(event.getType());
-const isOutputEvent = (event: Event) => [1, 4].includes(event.getType());
+const isInputEvent = (event: Event) =>
+  [Event.Type.INPUT.valueOf(), Event.Type.DECLARED_INPUT.valueOf()].includes(event.getType());
+const isOutputEvent = (event: Event) =>
+  [Event.Type.OUTPUT.valueOf(), Event.Type.DECLARED_OUTPUT.valueOf()].includes(event.getType());
 
 export interface LineageViewProps {
   target: Artifact;
@@ -124,15 +120,13 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
       {
         title: 'Artifact',
         elements: artifacts.map((artifact) => ({
-            artifact,
-            title: getResourceProperty(artifact, ArtifactProperties.NAME),
-            desc: getResourceProperty(artifact, ArtifactProperties.DESCRIPTION),
+            resource: artifact,
             prev: true,
             next: true
           })
         )
       }
-    ] as CardDetails[];
+    ];
   }
 
   private buildExecutionCards(executions: Execution[]): CardDetails[] {
@@ -140,20 +134,13 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
       {
         title: 'Execution',
         elements: executions.map((execution) => ({
-          title: getResourceProperty(execution, ExecutionProperties.NAME),
-          // desc: getResourceProperty(execution, ExecutionProperties.PIPELINE_NAME),
-          desc: String(execution.getId()),
-          prev: true,
-          next: true
+            resource: execution,
+            prev: true,
+            next: true
           })
         )
       }
-    ] as CardDetails[];
-  }
-
-  // @ts-ignore
-  private static logProto(proto: any): void {
-    console.log(JSON.stringify(proto.toObject(), null, 2))
+    ];
   }
 
   private async loadData(id: number): Promise<string> {

--- a/frontend/src/pages/LineageView.tsx
+++ b/frontend/src/pages/LineageView.tsx
@@ -123,6 +123,7 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
       {
         title: 'Artifact',
         elements: artifacts.map((artifact) => ({
+            artifact,
             title: getResourceProperty(artifact, ArtifactProperties.NAME),
             desc: getResourceProperty(artifact, ArtifactProperties.DESCRIPTION),
             prev: true,
@@ -164,14 +165,6 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
       await this.metadataStoreService.getEventsByArtifactIDs(getEventsByArtifactIDsRequest);
 
     const events = getEventsByArtifactIDsResponse.getEventsList();
-
-    // // Sanity logging
-    // console.log(`Found ${events.length} event`);
-    // events.forEach((event) => {
-    //   console.log("EVENT");
-    //   console.log(JSON.stringify(event.toObject(), null, 2));
-    //   console.log(isOutputEvent(event) ? "OUTPUT" : "INPUT");
-    // });
 
     const outputExecutionIds =
       events.filter(isOutputEvent)

--- a/frontend/src/pages/LineageView.tsx
+++ b/frontend/src/pages/LineageView.tsx
@@ -144,6 +144,7 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
   }
 
   private async loadData(id: number): Promise<string> {
+    // TODO: Optimize async calls with Promise.all()
     const getEventsByArtifactIDsRequest = new GetEventsByArtifactIDsRequest();
     getEventsByArtifactIDsRequest.addArtifactIds(id);
 

--- a/frontend/src/pages/LineageView.tsx
+++ b/frontend/src/pages/LineageView.tsx
@@ -33,6 +33,7 @@ import {
 } from '../generated/src/apis/metadata/metadata_store_service_pb';
 import {MetadataStoreServicePromiseClient} from "../generated/src/apis/metadata/metadata_store_service_grpc_web_pb";
 
+// TODO: I was having trouble getting these enum values to work so I made this hack.
 // https://github.com/google/ml-metadata/blob/master/ml_metadata/proto/metadata_store.proto#L108
 // 1 = ml_metadata.Event.DECLARED_OUTPUT
 // 2 = ml_metadata.Event.DECLARED_INPUT
@@ -156,8 +157,6 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
   }
 
   private async loadData(id: number): Promise<string> {
-    console.log(`Fetching data for ${id}`);
-
     const getEventsByArtifactIDsRequest = new GetEventsByArtifactIDsRequest();
     getEventsByArtifactIDsRequest.addArtifactIds(id);
 
@@ -167,12 +166,9 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
     const events = getEventsByArtifactIDsResponse.getEventsList();
 
     const outputExecutionIds =
-      events.filter(isOutputEvent)
-        .map((event) => (event.getExecutionId()));
-
+      events.filter(isOutputEvent).map((event) => (event.getExecutionId()));
     const inputExecutionIds =
-      events.filter(isInputEvent)
-        .map((event) => (event.getExecutionId()));
+      events.filter(isInputEvent).map((event) => (event.getExecutionId()));
 
     const outputExecutions = await this.getExecutions(outputExecutionIds);
     const inputExecutions = await this.getExecutions(inputExecutionIds);
@@ -223,7 +219,6 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
     if (!actionBarRefObject.current) {return;}
 
     actionBarRefObject.current.pushHistory(target);
-    // TODO: This is being called with id === 0
     this.target = target;
   }
 

--- a/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
@@ -111,32 +111,32 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
               className="button"
               classes={
                 Object {
-                  "colorInherit": "MuiButton-colorInherit-144",
-                  "contained": "MuiButton-contained-134",
-                  "containedPrimary": "MuiButton-containedPrimary-135",
-                  "containedSecondary": "MuiButton-containedSecondary-136",
-                  "disabled": "MuiButton-disabled-143",
-                  "extendedFab": "MuiButton-extendedFab-141",
-                  "fab": "MuiButton-fab-140",
-                  "flat": "MuiButton-flat-128",
-                  "flatPrimary": "MuiButton-flatPrimary-129",
-                  "flatSecondary": "MuiButton-flatSecondary-130",
-                  "focusVisible": "MuiButton-focusVisible-142",
-                  "fullWidth": "MuiButton-fullWidth-148",
-                  "label": "MuiButton-label-124",
-                  "mini": "MuiButton-mini-145",
-                  "outlined": "MuiButton-outlined-131",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-132",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-133",
-                  "raised": "MuiButton-raised-137",
-                  "raisedPrimary": "MuiButton-raisedPrimary-138",
-                  "raisedSecondary": "MuiButton-raisedSecondary-139",
-                  "root": "MuiButton-root-123",
-                  "sizeLarge": "MuiButton-sizeLarge-147",
-                  "sizeSmall": "MuiButton-sizeSmall-146",
-                  "text": "MuiButton-text-125",
-                  "textPrimary": "MuiButton-textPrimary-126",
-                  "textSecondary": "MuiButton-textSecondary-127",
+                  "colorInherit": "MuiButton-colorInherit-153",
+                  "contained": "MuiButton-contained-143",
+                  "containedPrimary": "MuiButton-containedPrimary-144",
+                  "containedSecondary": "MuiButton-containedSecondary-145",
+                  "disabled": "MuiButton-disabled-152",
+                  "extendedFab": "MuiButton-extendedFab-150",
+                  "fab": "MuiButton-fab-149",
+                  "flat": "MuiButton-flat-137",
+                  "flatPrimary": "MuiButton-flatPrimary-138",
+                  "flatSecondary": "MuiButton-flatSecondary-139",
+                  "focusVisible": "MuiButton-focusVisible-151",
+                  "fullWidth": "MuiButton-fullWidth-157",
+                  "label": "MuiButton-label-133",
+                  "mini": "MuiButton-mini-154",
+                  "outlined": "MuiButton-outlined-140",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-141",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-142",
+                  "raised": "MuiButton-raised-146",
+                  "raisedPrimary": "MuiButton-raisedPrimary-147",
+                  "raisedSecondary": "MuiButton-raisedSecondary-148",
+                  "root": "MuiButton-root-132",
+                  "sizeLarge": "MuiButton-sizeLarge-156",
+                  "sizeSmall": "MuiButton-sizeSmall-155",
+                  "text": "MuiButton-text-134",
+                  "textPrimary": "MuiButton-textPrimary-135",
+                  "textSecondary": "MuiButton-textSecondary-136",
                 }
               }
               color="default"
@@ -151,22 +151,22 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
               variant="text"
             >
               <WithStyles(ButtonBase)
-                className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button"
+                className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button"
                 component="button"
                 disabled={false}
                 focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-142"
+                focusVisibleClassName="MuiButton-focusVisible-151"
                 onClick={[Function]}
                 type="button"
               >
                 <ButtonBase
                   centerRipple={false}
-                  className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button"
+                  className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-150",
-                      "focusVisible": "MuiButtonBase-focusVisible-151",
-                      "root": "MuiButtonBase-root-149",
+                      "disabled": "MuiButtonBase-disabled-159",
+                      "focusVisible": "MuiButtonBase-focusVisible-160",
+                      "root": "MuiButtonBase-root-158",
                     }
                   }
                   component="button"
@@ -174,13 +174,13 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   disableTouchRipple={false}
                   disabled={false}
                   focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-142"
+                  focusVisibleClassName="MuiButton-focusVisible-151"
                   onClick={[Function]}
                   tabIndex="0"
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-149 MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button"
+                    className="MuiButtonBase-root-158 MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -198,7 +198,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                     type="button"
                   >
                     <span
-                      className="MuiButton-label-124"
+                      className="MuiButton-label-133"
                     >
                       <span>
                         Overview
@@ -216,25 +216,25 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-165",
-                              "childLeaving": "MuiTouchRipple-childLeaving-166",
-                              "childPulsate": "MuiTouchRipple-childPulsate-167",
-                              "ripple": "MuiTouchRipple-ripple-162",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-164",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-163",
-                              "root": "MuiTouchRipple-root-161",
+                              "child": "MuiTouchRipple-child-174",
+                              "childLeaving": "MuiTouchRipple-childLeaving-175",
+                              "childPulsate": "MuiTouchRipple-childPulsate-176",
+                              "ripple": "MuiTouchRipple-ripple-171",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-173",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-172",
+                              "root": "MuiTouchRipple-root-170",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-161"
+                            className="MuiTouchRipple-root-170"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-161"
+                              className="MuiTouchRipple-root-170"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -254,32 +254,32 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
               className="button active"
               classes={
                 Object {
-                  "colorInherit": "MuiButton-colorInherit-144",
-                  "contained": "MuiButton-contained-134",
-                  "containedPrimary": "MuiButton-containedPrimary-135",
-                  "containedSecondary": "MuiButton-containedSecondary-136",
-                  "disabled": "MuiButton-disabled-143",
-                  "extendedFab": "MuiButton-extendedFab-141",
-                  "fab": "MuiButton-fab-140",
-                  "flat": "MuiButton-flat-128",
-                  "flatPrimary": "MuiButton-flatPrimary-129",
-                  "flatSecondary": "MuiButton-flatSecondary-130",
-                  "focusVisible": "MuiButton-focusVisible-142",
-                  "fullWidth": "MuiButton-fullWidth-148",
-                  "label": "MuiButton-label-124",
-                  "mini": "MuiButton-mini-145",
-                  "outlined": "MuiButton-outlined-131",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-132",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-133",
-                  "raised": "MuiButton-raised-137",
-                  "raisedPrimary": "MuiButton-raisedPrimary-138",
-                  "raisedSecondary": "MuiButton-raisedSecondary-139",
-                  "root": "MuiButton-root-123",
-                  "sizeLarge": "MuiButton-sizeLarge-147",
-                  "sizeSmall": "MuiButton-sizeSmall-146",
-                  "text": "MuiButton-text-125",
-                  "textPrimary": "MuiButton-textPrimary-126",
-                  "textSecondary": "MuiButton-textSecondary-127",
+                  "colorInherit": "MuiButton-colorInherit-153",
+                  "contained": "MuiButton-contained-143",
+                  "containedPrimary": "MuiButton-containedPrimary-144",
+                  "containedSecondary": "MuiButton-containedSecondary-145",
+                  "disabled": "MuiButton-disabled-152",
+                  "extendedFab": "MuiButton-extendedFab-150",
+                  "fab": "MuiButton-fab-149",
+                  "flat": "MuiButton-flat-137",
+                  "flatPrimary": "MuiButton-flatPrimary-138",
+                  "flatSecondary": "MuiButton-flatSecondary-139",
+                  "focusVisible": "MuiButton-focusVisible-151",
+                  "fullWidth": "MuiButton-fullWidth-157",
+                  "label": "MuiButton-label-133",
+                  "mini": "MuiButton-mini-154",
+                  "outlined": "MuiButton-outlined-140",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-141",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-142",
+                  "raised": "MuiButton-raised-146",
+                  "raisedPrimary": "MuiButton-raisedPrimary-147",
+                  "raisedSecondary": "MuiButton-raisedSecondary-148",
+                  "root": "MuiButton-root-132",
+                  "sizeLarge": "MuiButton-sizeLarge-156",
+                  "sizeSmall": "MuiButton-sizeSmall-155",
+                  "text": "MuiButton-text-134",
+                  "textPrimary": "MuiButton-textPrimary-135",
+                  "textSecondary": "MuiButton-textSecondary-136",
                 }
               }
               color="default"
@@ -294,22 +294,22 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
               variant="text"
             >
               <WithStyles(ButtonBase)
-                className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button active"
+                className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button active"
                 component="button"
                 disabled={false}
                 focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-142"
+                focusVisibleClassName="MuiButton-focusVisible-151"
                 onClick={[Function]}
                 type="button"
               >
                 <ButtonBase
                   centerRipple={false}
-                  className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button active"
+                  className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button active"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-150",
-                      "focusVisible": "MuiButtonBase-focusVisible-151",
-                      "root": "MuiButtonBase-root-149",
+                      "disabled": "MuiButtonBase-disabled-159",
+                      "focusVisible": "MuiButtonBase-focusVisible-160",
+                      "root": "MuiButtonBase-root-158",
                     }
                   }
                   component="button"
@@ -317,13 +317,13 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   disableTouchRipple={false}
                   disabled={false}
                   focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-142"
+                  focusVisibleClassName="MuiButton-focusVisible-151"
                   onClick={[Function]}
                   tabIndex="0"
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-149 MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button active"
+                    className="MuiButtonBase-root-158 MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button active"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -341,7 +341,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                     type="button"
                   >
                     <span
-                      className="MuiButton-label-124"
+                      className="MuiButton-label-133"
                     >
                       <span>
                         Lineage Explorer
@@ -359,25 +359,25 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-165",
-                              "childLeaving": "MuiTouchRipple-childLeaving-166",
-                              "childPulsate": "MuiTouchRipple-childPulsate-167",
-                              "ripple": "MuiTouchRipple-ripple-162",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-164",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-163",
-                              "root": "MuiTouchRipple-root-161",
+                              "child": "MuiTouchRipple-child-174",
+                              "childLeaving": "MuiTouchRipple-childLeaving-175",
+                              "childPulsate": "MuiTouchRipple-childPulsate-176",
+                              "ripple": "MuiTouchRipple-ripple-171",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-173",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-172",
+                              "root": "MuiTouchRipple-root-170",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-161"
+                            className="MuiTouchRipple-root-170"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-161"
+                              className="MuiTouchRipple-root-170"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -998,32 +998,32 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   className="actionButton"
                   classes={
                     Object {
-                      "colorInherit": "MuiButton-colorInherit-144",
-                      "contained": "MuiButton-contained-134",
-                      "containedPrimary": "MuiButton-containedPrimary-135",
-                      "containedSecondary": "MuiButton-containedSecondary-136",
-                      "disabled": "MuiButton-disabled-143",
-                      "extendedFab": "MuiButton-extendedFab-141",
-                      "fab": "MuiButton-fab-140",
-                      "flat": "MuiButton-flat-128",
-                      "flatPrimary": "MuiButton-flatPrimary-129",
-                      "flatSecondary": "MuiButton-flatSecondary-130",
-                      "focusVisible": "MuiButton-focusVisible-142",
-                      "fullWidth": "MuiButton-fullWidth-148",
-                      "label": "MuiButton-label-124",
-                      "mini": "MuiButton-mini-145",
-                      "outlined": "MuiButton-outlined-131",
-                      "outlinedPrimary": "MuiButton-outlinedPrimary-132",
-                      "outlinedSecondary": "MuiButton-outlinedSecondary-133",
-                      "raised": "MuiButton-raised-137",
-                      "raisedPrimary": "MuiButton-raisedPrimary-138",
-                      "raisedSecondary": "MuiButton-raisedSecondary-139",
-                      "root": "MuiButton-root-123",
-                      "sizeLarge": "MuiButton-sizeLarge-147",
-                      "sizeSmall": "MuiButton-sizeSmall-146",
-                      "text": "MuiButton-text-125",
-                      "textPrimary": "MuiButton-textPrimary-126",
-                      "textSecondary": "MuiButton-textSecondary-127",
+                      "colorInherit": "MuiButton-colorInherit-153",
+                      "contained": "MuiButton-contained-143",
+                      "containedPrimary": "MuiButton-containedPrimary-144",
+                      "containedSecondary": "MuiButton-containedSecondary-145",
+                      "disabled": "MuiButton-disabled-152",
+                      "extendedFab": "MuiButton-extendedFab-150",
+                      "fab": "MuiButton-fab-149",
+                      "flat": "MuiButton-flat-137",
+                      "flatPrimary": "MuiButton-flatPrimary-138",
+                      "flatSecondary": "MuiButton-flatSecondary-139",
+                      "focusVisible": "MuiButton-focusVisible-151",
+                      "fullWidth": "MuiButton-fullWidth-157",
+                      "label": "MuiButton-label-133",
+                      "mini": "MuiButton-mini-154",
+                      "outlined": "MuiButton-outlined-140",
+                      "outlinedPrimary": "MuiButton-outlinedPrimary-141",
+                      "outlinedSecondary": "MuiButton-outlinedSecondary-142",
+                      "raised": "MuiButton-raised-146",
+                      "raisedPrimary": "MuiButton-raisedPrimary-147",
+                      "raisedSecondary": "MuiButton-raisedSecondary-148",
+                      "root": "MuiButton-root-132",
+                      "sizeLarge": "MuiButton-sizeLarge-156",
+                      "sizeSmall": "MuiButton-sizeSmall-155",
+                      "text": "MuiButton-text-134",
+                      "textPrimary": "MuiButton-textPrimary-135",
+                      "textSecondary": "MuiButton-textSecondary-136",
                     }
                   }
                   color="default"
@@ -1038,22 +1038,22 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   variant="text"
                 >
                   <WithStyles(ButtonBase)
-                    className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 actionButton"
+                    className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 actionButton"
                     component="button"
                     disabled={false}
                     focusRipple={true}
-                    focusVisibleClassName="MuiButton-focusVisible-142"
+                    focusVisibleClassName="MuiButton-focusVisible-151"
                     onClick={[Function]}
                     type="button"
                   >
                     <ButtonBase
                       centerRipple={false}
-                      className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 actionButton"
+                      className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 actionButton"
                       classes={
                         Object {
-                          "disabled": "MuiButtonBase-disabled-150",
-                          "focusVisible": "MuiButtonBase-focusVisible-151",
-                          "root": "MuiButtonBase-root-149",
+                          "disabled": "MuiButtonBase-disabled-159",
+                          "focusVisible": "MuiButtonBase-focusVisible-160",
+                          "root": "MuiButtonBase-root-158",
                         }
                       }
                       component="button"
@@ -1061,13 +1061,13 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       disableTouchRipple={false}
                       disabled={false}
                       focusRipple={true}
-                      focusVisibleClassName="MuiButton-focusVisible-142"
+                      focusVisibleClassName="MuiButton-focusVisible-151"
                       onClick={[Function]}
                       tabIndex="0"
                       type="button"
                     >
                       <button
-                        className="MuiButtonBase-root-149 MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 actionButton"
+                        className="MuiButtonBase-root-158 MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 actionButton"
                         disabled={false}
                         onBlur={[Function]}
                         onClick={[Function]}
@@ -1085,7 +1085,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                         type="button"
                       >
                         <span
-                          className="MuiButton-label-124"
+                          className="MuiButton-label-133"
                         >
                           <pure(ReplayIcon)>
                             <ReplayIcon>
@@ -1093,15 +1093,15 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                                 <SvgIcon
                                   classes={
                                     Object {
-                                      "colorAction": "MuiSvgIcon-colorAction-155",
-                                      "colorDisabled": "MuiSvgIcon-colorDisabled-157",
-                                      "colorError": "MuiSvgIcon-colorError-156",
-                                      "colorPrimary": "MuiSvgIcon-colorPrimary-153",
-                                      "colorSecondary": "MuiSvgIcon-colorSecondary-154",
-                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-158",
-                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-160",
-                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-159",
-                                      "root": "MuiSvgIcon-root-152",
+                                      "colorAction": "MuiSvgIcon-colorAction-164",
+                                      "colorDisabled": "MuiSvgIcon-colorDisabled-166",
+                                      "colorError": "MuiSvgIcon-colorError-165",
+                                      "colorPrimary": "MuiSvgIcon-colorPrimary-162",
+                                      "colorSecondary": "MuiSvgIcon-colorSecondary-163",
+                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-167",
+                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-169",
+                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-168",
+                                      "root": "MuiSvgIcon-root-161",
                                     }
                                   }
                                   color="inherit"
@@ -1111,7 +1111,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    className="MuiSvgIcon-root-152"
+                                    className="MuiSvgIcon-root-161"
                                     focusable="false"
                                     role="presentation"
                                     viewBox="0 0 24 24"
@@ -1142,25 +1142,25 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                               center={false}
                               classes={
                                 Object {
-                                  "child": "MuiTouchRipple-child-165",
-                                  "childLeaving": "MuiTouchRipple-childLeaving-166",
-                                  "childPulsate": "MuiTouchRipple-childPulsate-167",
-                                  "ripple": "MuiTouchRipple-ripple-162",
-                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-164",
-                                  "rippleVisible": "MuiTouchRipple-rippleVisible-163",
-                                  "root": "MuiTouchRipple-root-161",
+                                  "child": "MuiTouchRipple-child-174",
+                                  "childLeaving": "MuiTouchRipple-childLeaving-175",
+                                  "childPulsate": "MuiTouchRipple-childPulsate-176",
+                                  "ripple": "MuiTouchRipple-ripple-171",
+                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-173",
+                                  "rippleVisible": "MuiTouchRipple-rippleVisible-172",
+                                  "root": "MuiTouchRipple-root-170",
                                 }
                               }
                             >
                               <TransitionGroup
                                 childFactory={[Function]}
-                                className="MuiTouchRipple-root-161"
+                                className="MuiTouchRipple-root-170"
                                 component="span"
                                 enter={true}
                                 exit={true}
                               >
                                 <span
-                                  className="MuiTouchRipple-root-161"
+                                  className="MuiTouchRipple-root-170"
                                 />
                               </TransitionGroup>
                             </TouchRipple>
@@ -1193,32 +1193,298 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 Object {
                   "elements": Array [
                     Object {
-                      "desc": "This is really cool",
-                      "next": true,
-                      "title": "Artifact 1",
-                    },
-                    Object {
-                      "desc": "This is also kinda cool",
-                      "next": true,
-                      "title": "Artifact 2",
-                    },
-                  ],
-                  "title": "Notebook",
-                },
-                Object {
-                  "elements": Array [
-                    Object {
+                      "artifact": Object {
+                        "array": Array [
+                          1,
+                          1,
+                          "gs://my-bucket/mnist",
+                          Array [
+                            Array [
+                              "__ALL_META__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                              ],
+                            ],
+                            Array [
+                              "create_time",
+                              Array [
+                                undefined,
+                                undefined,
+                                "2019-06-12T01:21:48.259263Z",
+                              ],
+                            ],
+                            Array [
+                              "description",
+                              Array [
+                                undefined,
+                                undefined,
+                                "A really great model",
+                              ],
+                            ],
+                            Array [
+                              "name",
+                              Array [
+                                undefined,
+                                undefined,
+                                "test model",
+                              ],
+                            ],
+                            Array [
+                              "version",
+                              Array [
+                                undefined,
+                                undefined,
+                                "v1",
+                              ],
+                            ],
+                          ],
+                          Array [
+                            Array [
+                              "__kf_run__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "1",
+                              ],
+                            ],
+                            Array [
+                              "__kf_workspace__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "workspace-1",
+                              ],
+                            ],
+                          ],
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": Object {
+                          "4": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__ALL_META__": Object {
+                                "key": "__ALL_META__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "create_time": Object {
+                                "key": "create_time",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "description": Object {
+                                "key": "description",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "name": Object {
+                                "key": "name",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "version": Object {
+                                "key": "version",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                          "5": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__kf_run__": Object {
+                                "key": "__kf_run__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "__kf_workspace__": Object {
+                                "key": "__kf_workspace__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                        },
+                      },
+                      "desc": "A really great model",
                       "next": true,
                       "prev": true,
-                      "title": "Artifact w/o desc",
-                    },
-                    Object {
-                      "desc": "Lorem ipsum",
-                      "next": true,
-                      "title": "Artifact that should have overflowing text",
+                      "title": "test model",
                     },
                   ],
-                  "title": "Datasets",
+                  "title": "Artifact",
                 },
               ]
             }
@@ -1242,8 +1508,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 <EdgeCanvas
                   cardArray={
                     Array [
-                      2,
-                      2,
+                      1,
                     ]
                   }
                   reverseEdges={false}
@@ -1694,1332 +1959,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                         </svg>
                       </styled.svg>
                     </LineChart>
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 67,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 67,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="0-1"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={68}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 68"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 68"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 67,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 67,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 68  C
-      0
-      68
-      0
-      68
-      5
-      68
-      C
-      10
-      68
-      20
-      68
-      48.33
-      57.15
-      C
-      76.67
-      46.3
-      123.33
-      24.61
-      151.67
-      13.76
-     C
-      180
-      2.91
-      190
-      2.91
-      195
-      2.91
-    L 200 2.91 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 68  C
-      0
-      68
-      0
-      68
-      5
-      68
-      C
-      10
-      68
-      20
-      68
-      48.33
-      57.15
-      C
-      76.67
-      46.3
-      123.33
-      24.61
-      151.67
-      13.76
-     C
-      180
-      2.91
-      190
-      2.91
-      195
-      2.91
-    L 200 2.91 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 67,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 67,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 67,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 201,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 201,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="1-0"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={202}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 202"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 202"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 201,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 201,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 202  C
-      0
-      202
-      0
-      202
-      5
-      202
-      C
-      10
-      202
-      20
-      202
-      48.33
-      168.99
-      C
-      76.67
-      135.98
-      123.33
-      69.96
-      151.67
-      36.95
-     C
-      180
-      3.94
-      190
-      3.94
-      195
-      3.94
-    L 200 3.94 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 202  C
-      0
-      202
-      0
-      202
-      5
-      202
-      C
-      10
-      202
-      20
-      202
-      48.33
-      168.99
-      C
-      76.67
-      135.98
-      123.33
-      69.96
-      151.67
-      36.95
-     C
-      180
-      3.94
-      190
-      3.94
-      195
-      3.94
-    L 200 3.94 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 201,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 201,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 201,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 268,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 268,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="1-1"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={269}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 269"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 269"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 268,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 268,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 269  C
-      0
-      269
-      0
-      269
-      5
-      269
-      C
-      10
-      269
-      20
-      269
-      48.33
-      224.5
-      C
-      76.67
-      180
-      123.33
-      91
-      151.67
-      46.49
-     C
-      180
-      1.99
-      190
-      1.99
-      195
-      1.99
-    L 200 1.99 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 269  C
-      0
-      269
-      0
-      269
-      5
-      269
-      C
-      10
-      269
-      20
-      269
-      48.33
-      224.5
-      C
-      76.67
-      180
-      123.33
-      91
-      151.67
-      46.49
-     C
-      180
-      1.99
-      190
-      1.99
-      195
-      1.99
-    L 200 1.99 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 268,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 268,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 268,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
                   </div>
                 </EdgeCanvas>
                 <LineageCard
@@ -3029,19 +1968,300 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   rows={
                     Array [
                       Object {
-                        "desc": "This is really cool",
+                        "artifact": Object {
+                          "array": Array [
+                            1,
+                            1,
+                            "gs://my-bucket/mnist",
+                            Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                          ],
+                          "arrayIndexOffset_": -1,
+                          "convertedPrimitiveFields_": Object {},
+                          "messageId_": undefined,
+                          "pivot_": 1.7976931348623157e+308,
+                          "wrappers_": Object {
+                            "4": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__ALL_META__": Object {
+                                  "key": "__ALL_META__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "create_time": Object {
+                                  "key": "create_time",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "description": Object {
+                                  "key": "description",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "name": Object {
+                                  "key": "name",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "version": Object {
+                                  "key": "version",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                            "5": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__kf_run__": Object {
+                                  "key": "__kf_run__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "__kf_workspace__": Object {
+                                  "key": "__kf_workspace__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                          },
+                        },
+                        "desc": "A really great model",
                         "next": true,
-                        "title": "Artifact 1",
-                      },
-                      Object {
-                        "desc": "This is also kinda cool",
-                        "next": true,
-                        "title": "Artifact 2",
+                        "prev": true,
+                        "title": "test model",
                       },
                     ]
                   }
                   setLineageViewTarget={[Function]}
-                  title="Notebook"
+                  title="Artifact"
                   type="artifact"
                 >
                   <div
@@ -3051,61 +2271,308 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       className="cardTitle"
                     >
                       <h3>
-                        Notebook
+                        Artifact
                       </h3>
                     </div>
                     <div
                       className="cardBody"
                     >
                       <LineageCardRow
-                        description="This is really cool"
-                        hideRadio={false}
-                        isLastRow={false}
-                        key="0"
-                        leftAffordance={false}
-                        rightAffordance={true}
-                        setLineageViewTarget={[Function]}
-                        title="Artifact 1"
-                      >
-                        <div
-                          className="cardRow "
-                        >
-                          <div>
-                            <input
-                              className="form-radio"
-                              name=""
-                              onClick={[Function]}
-                              type="radio"
-                              value=""
-                            />
-                          </div>
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              Artifact 1
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              This is really cool
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                      <LineageCardRow
-                        description="This is also kinda cool"
+                        artifact={
+                          Object {
+                            "array": Array [
+                              1,
+                              1,
+                              "gs://my-bucket/mnist",
+                              Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                            ],
+                            "arrayIndexOffset_": -1,
+                            "convertedPrimitiveFields_": Object {},
+                            "messageId_": undefined,
+                            "pivot_": 1.7976931348623157e+308,
+                            "wrappers_": Object {
+                              "4": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__ALL_META__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                  ],
+                                  Array [
+                                    "create_time",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                  ],
+                                  Array [
+                                    "description",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "name",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "version",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__ALL_META__": Object {
+                                    "key": "__ALL_META__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "create_time": Object {
+                                    "key": "create_time",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "2019-06-12T01:21:48.259263Z",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "description": Object {
+                                    "key": "description",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "A really great model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "name": Object {
+                                    "key": "name",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "test model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "version": Object {
+                                    "key": "version",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "v1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                              "5": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__kf_run__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                  ],
+                                  Array [
+                                    "__kf_workspace__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__kf_run__": Object {
+                                    "key": "__kf_run__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "__kf_workspace__": Object {
+                                    "key": "__kf_workspace__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "workspace-1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                            },
+                          }
+                        }
+                        description="A really great model"
                         hideRadio={false}
                         isLastRow={true}
-                        key="1"
-                        leftAffordance={false}
+                        key="0"
+                        leftAffordance={true}
                         rightAffordance={true}
                         setLineageViewTarget={[Function]}
-                        title="Artifact 2"
+                        title="test model"
                       >
                         <div
                           className="cardRow lastRow"
@@ -3123,133 +2590,18 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             <p
                               className="rowTitle"
                             >
-                              Artifact 2
+                              test model
                             </p>
                             <p
                               className="rowDesc"
                             >
-                              This is also kinda cool
+                              A really great model
                             </p>
-                          </footer>
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                    </div>
-                  </div>
-                </LineageCard>
-                <LineageCard
-                  addSpacer={true}
-                  isTarget={false}
-                  key="1"
-                  rows={
-                    Array [
-                      Object {
-                        "next": true,
-                        "prev": true,
-                        "title": "Artifact w/o desc",
-                      },
-                      Object {
-                        "desc": "Lorem ipsum",
-                        "next": true,
-                        "title": "Artifact that should have overflowing text",
-                      },
-                    ]
-                  }
-                  setLineageViewTarget={[Function]}
-                  title="Datasets"
-                  type="artifact"
-                >
-                  <div
-                    className="cardContainer artifact addSpacer"
-                  >
-                    <div
-                      className="cardTitle"
-                    >
-                      <h3>
-                        Datasets
-                      </h3>
-                    </div>
-                    <div
-                      className="cardBody"
-                    >
-                      <LineageCardRow
-                        hideRadio={false}
-                        isLastRow={false}
-                        key="0"
-                        leftAffordance={true}
-                        rightAffordance={true}
-                        setLineageViewTarget={[Function]}
-                        title="Artifact w/o desc"
-                      >
-                        <div
-                          className="cardRow "
-                        >
-                          <div>
-                            <input
-                              className="form-radio"
-                              name=""
-                              onClick={[Function]}
-                              type="radio"
-                              value=""
-                            />
-                          </div>
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              Artifact w/o desc
-                            </p>
-                            <p
-                              className="rowDesc"
-                            />
                           </footer>
                           <div
                             className="edgeLeft"
                             key="edgeLeft"
                           />
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                      <LineageCardRow
-                        description="Lorem ipsum"
-                        hideRadio={false}
-                        isLastRow={true}
-                        key="1"
-                        leftAffordance={false}
-                        rightAffordance={true}
-                        setLineageViewTarget={[Function]}
-                        title="Artifact that should have overflowing text"
-                      >
-                        <div
-                          className="cardRow lastRow"
-                        >
-                          <div>
-                            <input
-                              className="form-radio"
-                              name=""
-                              onClick={[Function]}
-                              type="radio"
-                              value=""
-                            />
-                          </div>
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              Artifact that should have overflowing text
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              Lorem ipsum
-                            </p>
-                          </footer>
                           <div
                             className="edgeRight"
                             key="edgeRight"
@@ -3266,14 +2618,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
             cards={
               Array [
                 Object {
-                  "elements": Array [
-                    Object {
-                      "desc": "13,201 Examples",
-                      "next": true,
-                      "prev": true,
-                      "title": "test model",
-                    },
-                  ],
+                  "elements": Array [],
                   "title": "Execution",
                 },
               ]
@@ -3295,7 +2640,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 <EdgeCanvas
                   cardArray={
                     Array [
-                      1,
+                      0,
                     ]
                   }
                   reverseEdges={false}
@@ -3303,465 +2648,13 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 >
                   <div
                     className="edgeCanvas"
-                  >
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 0,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="0-0"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={1}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 1"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 1"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                  </div>
+                  />
                 </EdgeCanvas>
                 <LineageCard
                   addSpacer={false}
                   isTarget={false}
                   key="0"
-                  rows={
-                    Array [
-                      Object {
-                        "desc": "13,201 Examples",
-                        "next": true,
-                        "prev": true,
-                        "title": "test model",
-                      },
-                    ]
-                  }
+                  rows={Array []}
                   title="Execution"
                   type="execution"
                 >
@@ -3777,45 +2670,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                     </div>
                     <div
                       className="cardBody"
-                    >
-                      <LineageCardRow
-                        description="13,201 Examples"
-                        hideRadio={true}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
-                        rightAffordance={true}
-                        title="test model"
-                      >
-                        <div
-                          className="cardRow lastRow"
-                        >
-                          <div
-                            className="noRadio"
-                          />
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              test model
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              13,201 Examples
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeLeft"
-                            key="edgeLeft"
-                          />
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                    </div>
+                    />
                   </div>
                 </LineageCard>
               </div>
@@ -3827,13 +2682,298 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 Object {
                   "elements": Array [
                     Object {
-                      "desc": "13,201 Examples",
+                      "artifact": Object {
+                        "array": Array [
+                          1,
+                          1,
+                          "gs://my-bucket/mnist",
+                          Array [
+                            Array [
+                              "__ALL_META__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                              ],
+                            ],
+                            Array [
+                              "create_time",
+                              Array [
+                                undefined,
+                                undefined,
+                                "2019-06-12T01:21:48.259263Z",
+                              ],
+                            ],
+                            Array [
+                              "description",
+                              Array [
+                                undefined,
+                                undefined,
+                                "A really great model",
+                              ],
+                            ],
+                            Array [
+                              "name",
+                              Array [
+                                undefined,
+                                undefined,
+                                "test model",
+                              ],
+                            ],
+                            Array [
+                              "version",
+                              Array [
+                                undefined,
+                                undefined,
+                                "v1",
+                              ],
+                            ],
+                          ],
+                          Array [
+                            Array [
+                              "__kf_run__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "1",
+                              ],
+                            ],
+                            Array [
+                              "__kf_workspace__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "workspace-1",
+                              ],
+                            ],
+                          ],
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": Object {
+                          "4": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__ALL_META__": Object {
+                                "key": "__ALL_META__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "create_time": Object {
+                                "key": "create_time",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "description": Object {
+                                "key": "description",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "name": Object {
+                                "key": "name",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "version": Object {
+                                "key": "version",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                          "5": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__kf_run__": Object {
+                                "key": "__kf_run__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "__kf_workspace__": Object {
+                                "key": "__kf_workspace__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                        },
+                      },
+                      "desc": "A really great model",
                       "next": true,
                       "prev": true,
                       "title": "test model",
                     },
                   ],
-                  "title": "Execution",
+                  "title": "Artifact",
                 },
               ]
             }
@@ -4316,14 +3456,299 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   rows={
                     Array [
                       Object {
-                        "desc": "13,201 Examples",
+                        "artifact": Object {
+                          "array": Array [
+                            1,
+                            1,
+                            "gs://my-bucket/mnist",
+                            Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                          ],
+                          "arrayIndexOffset_": -1,
+                          "convertedPrimitiveFields_": Object {},
+                          "messageId_": undefined,
+                          "pivot_": 1.7976931348623157e+308,
+                          "wrappers_": Object {
+                            "4": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__ALL_META__": Object {
+                                  "key": "__ALL_META__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "create_time": Object {
+                                  "key": "create_time",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "description": Object {
+                                  "key": "description",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "name": Object {
+                                  "key": "name",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "version": Object {
+                                  "key": "version",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                            "5": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__kf_run__": Object {
+                                  "key": "__kf_run__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "__kf_workspace__": Object {
+                                  "key": "__kf_workspace__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                          },
+                        },
+                        "desc": "A really great model",
                         "next": true,
                         "prev": true,
                         "title": "test model",
                       },
                     ]
                   }
-                  title="Execution"
+                  title="Artifact"
                   type="artifact"
                 >
                   <div
@@ -4333,14 +3758,301 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       className="cardTitle"
                     >
                       <h3>
-                        Execution
+                        Artifact
                       </h3>
                     </div>
                     <div
                       className="cardBody"
                     >
                       <LineageCardRow
-                        description="13,201 Examples"
+                        artifact={
+                          Object {
+                            "array": Array [
+                              1,
+                              1,
+                              "gs://my-bucket/mnist",
+                              Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                            ],
+                            "arrayIndexOffset_": -1,
+                            "convertedPrimitiveFields_": Object {},
+                            "messageId_": undefined,
+                            "pivot_": 1.7976931348623157e+308,
+                            "wrappers_": Object {
+                              "4": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__ALL_META__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                  ],
+                                  Array [
+                                    "create_time",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                  ],
+                                  Array [
+                                    "description",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "name",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "version",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__ALL_META__": Object {
+                                    "key": "__ALL_META__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "create_time": Object {
+                                    "key": "create_time",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "2019-06-12T01:21:48.259263Z",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "description": Object {
+                                    "key": "description",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "A really great model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "name": Object {
+                                    "key": "name",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "test model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "version": Object {
+                                    "key": "version",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "v1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                              "5": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__kf_run__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                  ],
+                                  Array [
+                                    "__kf_workspace__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__kf_run__": Object {
+                                    "key": "__kf_run__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "__kf_workspace__": Object {
+                                    "key": "__kf_workspace__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "workspace-1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                            },
+                          }
+                        }
+                        description="A really great model"
                         hideRadio={true}
                         isLastRow={true}
                         key="0"
@@ -4363,7 +4075,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             <p
                               className="rowDesc"
                             >
-                              13,201 Examples
+                              A really great model
                             </p>
                           </footer>
                           <div
@@ -4386,14 +4098,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
             cards={
               Array [
                 Object {
-                  "elements": Array [
-                    Object {
-                      "desc": "13,201 Examples",
-                      "next": true,
-                      "prev": true,
-                      "title": "test model",
-                    },
-                  ],
+                  "elements": Array [],
                   "title": "Execution",
                 },
               ]
@@ -4415,7 +4120,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 <EdgeCanvas
                   cardArray={
                     Array [
-                      1,
+                      0,
                     ]
                   }
                   reverseEdges={false}
@@ -4423,465 +4128,13 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 >
                   <div
                     className="edgeCanvas"
-                  >
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 0,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="0-0"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={1}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 1"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 1"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                  </div>
+                  />
                 </EdgeCanvas>
                 <LineageCard
                   addSpacer={false}
                   isTarget={false}
                   key="0"
-                  rows={
-                    Array [
-                      Object {
-                        "desc": "13,201 Examples",
-                        "next": true,
-                        "prev": true,
-                        "title": "test model",
-                      },
-                    ]
-                  }
+                  rows={Array []}
                   title="Execution"
                   type="execution"
                 >
@@ -4897,45 +4150,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                     </div>
                     <div
                       className="cardBody"
-                    >
-                      <LineageCardRow
-                        description="13,201 Examples"
-                        hideRadio={true}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
-                        rightAffordance={true}
-                        title="test model"
-                      >
-                        <div
-                          className="cardRow lastRow"
-                        >
-                          <div
-                            className="noRadio"
-                          />
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              test model
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              13,201 Examples
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeLeft"
-                            key="edgeLeft"
-                          />
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                    </div>
+                    />
                   </div>
                 </LineageCard>
               </div>
@@ -4947,34 +4162,298 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 Object {
                   "elements": Array [
                     Object {
-                      "desc": "Maybe does something",
-                      "prev": true,
-                      "title": "Lol",
-                    },
-                    Object {
-                      "desc": "How fast should I descent the gradient",
+                      "artifact": Object {
+                        "array": Array [
+                          1,
+                          1,
+                          "gs://my-bucket/mnist",
+                          Array [
+                            Array [
+                              "__ALL_META__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                              ],
+                            ],
+                            Array [
+                              "create_time",
+                              Array [
+                                undefined,
+                                undefined,
+                                "2019-06-12T01:21:48.259263Z",
+                              ],
+                            ],
+                            Array [
+                              "description",
+                              Array [
+                                undefined,
+                                undefined,
+                                "A really great model",
+                              ],
+                            ],
+                            Array [
+                              "name",
+                              Array [
+                                undefined,
+                                undefined,
+                                "test model",
+                              ],
+                            ],
+                            Array [
+                              "version",
+                              Array [
+                                undefined,
+                                undefined,
+                                "v1",
+                              ],
+                            ],
+                          ],
+                          Array [
+                            Array [
+                              "__kf_run__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "1",
+                              ],
+                            ],
+                            Array [
+                              "__kf_workspace__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "workspace-1",
+                              ],
+                            ],
+                          ],
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": Object {
+                          "4": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__ALL_META__": Object {
+                                "key": "__ALL_META__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "create_time": Object {
+                                "key": "create_time",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "description": Object {
+                                "key": "description",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "name": Object {
+                                "key": "name",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "version": Object {
+                                "key": "version",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                          "5": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__kf_run__": Object {
+                                "key": "__kf_run__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "__kf_workspace__": Object {
+                                "key": "__kf_workspace__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                        },
+                      },
+                      "desc": "A really great model",
                       "next": true,
                       "prev": true,
-                      "title": "Skip factor",
+                      "title": "test model",
                     },
                   ],
-                  "title": "Hyperparameters",
-                },
-                Object {
-                  "elements": Array [
-                    Object {
-                      "desc": "http://foo.bar/x34s",
-                      "next": true,
-                      "prev": true,
-                      "title": "AWS Webserver",
-                    },
-                    Object {
-                      "desc": "Hosted via GCP",
-                      "prev": true,
-                      "title": "Product API",
-                    },
-                  ],
-                  "title": "Deployments",
+                  "title": "Artifact",
                 },
               ]
             }
@@ -4999,8 +4478,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 <EdgeCanvas
                   cardArray={
                     Array [
-                      2,
-                      2,
+                      1,
                     ]
                   }
                   reverseEdges={true}
@@ -5451,1332 +4929,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                         </svg>
                       </styled.svg>
                     </LineChart>
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 67,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 67,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 0,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="0-1"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={68}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 68"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 68"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 2.91  C
-      0
-      2.91
-      0
-      2.91
-      5
-      2.91
-      C
-      10
-      2.91
-      20
-      2.91
-      48.33
-      13.76
-      C
-      76.67
-      24.61
-      123.33
-      46.3
-      151.67
-      57.15
-     C
-      180
-      68
-      190
-      68
-      195
-      68
-    L 200 68 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 2.91  C
-      0
-      2.91
-      0
-      2.91
-      5
-      2.91
-      C
-      10
-      2.91
-      20
-      2.91
-      48.33
-      13.76
-      C
-      76.67
-      24.61
-      123.33
-      46.3
-      151.67
-      57.15
-     C
-      180
-      68
-      190
-      68
-      195
-      68
-    L 200 68 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 67,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={70}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 201,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 201,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 0,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="1-0"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={202}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 202"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 202"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 3.94  C
-      0
-      3.94
-      0
-      3.94
-      5
-      3.94
-      C
-      10
-      3.94
-      20
-      3.94
-      48.33
-      36.95
-      C
-      76.67
-      69.96
-      123.33
-      135.98
-      151.67
-      168.99
-     C
-      180
-      202
-      190
-      202
-      195
-      202
-    L 200 202 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 3.94  C
-      0
-      3.94
-      0
-      3.94
-      5
-      3.94
-      C
-      10
-      3.94
-      20
-      3.94
-      48.33
-      36.95
-      C
-      76.67
-      69.96
-      123.33
-      135.98
-      151.67
-      168.99
-     C
-      180
-      202
-      190
-      202
-      195
-      202
-    L 200 202 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 201,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={205}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 268,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 268,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 0,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="1-1"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={269}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 269"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 269"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 1.99  C
-      0
-      1.99
-      0
-      1.99
-      5
-      1.99
-      C
-      10
-      1.99
-      20
-      1.99
-      48.33
-      46.49
-      C
-      76.67
-      91
-      123.33
-      180
-      151.67
-      224.5
-     C
-      180
-      269
-      190
-      269
-      195
-      269
-    L 200 269 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 1.99  C
-      0
-      1.99
-      0
-      1.99
-      5
-      1.99
-      C
-      10
-      1.99
-      20
-      1.99
-      48.33
-      46.49
-      C
-      76.67
-      91
-      123.33
-      180
-      151.67
-      224.5
-     C
-      180
-      269
-      190
-      269
-      195
-      269
-    L 200 269 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 268,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={270}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
                   </div>
                 </EdgeCanvas>
                 <LineageCard
@@ -6786,20 +4938,300 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   rows={
                     Array [
                       Object {
-                        "desc": "Maybe does something",
-                        "prev": true,
-                        "title": "Lol",
-                      },
-                      Object {
-                        "desc": "How fast should I descent the gradient",
+                        "artifact": Object {
+                          "array": Array [
+                            1,
+                            1,
+                            "gs://my-bucket/mnist",
+                            Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                          ],
+                          "arrayIndexOffset_": -1,
+                          "convertedPrimitiveFields_": Object {},
+                          "messageId_": undefined,
+                          "pivot_": 1.7976931348623157e+308,
+                          "wrappers_": Object {
+                            "4": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__ALL_META__": Object {
+                                  "key": "__ALL_META__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "create_time": Object {
+                                  "key": "create_time",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "description": Object {
+                                  "key": "description",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "name": Object {
+                                  "key": "name",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "version": Object {
+                                  "key": "version",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                            "5": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__kf_run__": Object {
+                                  "key": "__kf_run__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "__kf_workspace__": Object {
+                                  "key": "__kf_workspace__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                          },
+                        },
+                        "desc": "A really great model",
                         "next": true,
                         "prev": true,
-                        "title": "Skip factor",
+                        "title": "test model",
                       },
                     ]
                   }
                   setLineageViewTarget={[Function]}
-                  title="Hyperparameters"
+                  title="Artifact"
                   type="artifact"
                 >
                   <div
@@ -6809,61 +5241,308 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       className="cardTitle"
                     >
                       <h3>
-                        Hyperparameters
+                        Artifact
                       </h3>
                     </div>
                     <div
                       className="cardBody"
                     >
                       <LineageCardRow
-                        description="Maybe does something"
-                        hideRadio={false}
-                        isLastRow={false}
-                        key="0"
-                        leftAffordance={true}
-                        rightAffordance={false}
-                        setLineageViewTarget={[Function]}
-                        title="Lol"
-                      >
-                        <div
-                          className="cardRow "
-                        >
-                          <div>
-                            <input
-                              className="form-radio"
-                              name=""
-                              onClick={[Function]}
-                              type="radio"
-                              value=""
-                            />
-                          </div>
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              Lol
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              Maybe does something
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeLeft"
-                            key="edgeLeft"
-                          />
-                        </div>
-                      </LineageCardRow>
-                      <LineageCardRow
-                        description="How fast should I descent the gradient"
+                        artifact={
+                          Object {
+                            "array": Array [
+                              1,
+                              1,
+                              "gs://my-bucket/mnist",
+                              Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                            ],
+                            "arrayIndexOffset_": -1,
+                            "convertedPrimitiveFields_": Object {},
+                            "messageId_": undefined,
+                            "pivot_": 1.7976931348623157e+308,
+                            "wrappers_": Object {
+                              "4": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__ALL_META__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                  ],
+                                  Array [
+                                    "create_time",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                  ],
+                                  Array [
+                                    "description",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "name",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "version",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__ALL_META__": Object {
+                                    "key": "__ALL_META__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "create_time": Object {
+                                    "key": "create_time",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "2019-06-12T01:21:48.259263Z",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "description": Object {
+                                    "key": "description",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "A really great model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "name": Object {
+                                    "key": "name",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "test model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "version": Object {
+                                    "key": "version",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "v1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                              "5": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__kf_run__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                  ],
+                                  Array [
+                                    "__kf_workspace__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__kf_run__": Object {
+                                    "key": "__kf_run__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "__kf_workspace__": Object {
+                                    "key": "__kf_workspace__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "workspace-1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                            },
+                          }
+                        }
+                        description="A really great model"
                         hideRadio={false}
                         isLastRow={true}
-                        key="1"
+                        key="0"
                         leftAffordance={true}
                         rightAffordance={true}
                         setLineageViewTarget={[Function]}
-                        title="Skip factor"
+                        title="test model"
                       >
                         <div
                           className="cardRow lastRow"
@@ -6881,12 +5560,12 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             <p
                               className="rowTitle"
                             >
-                              Skip factor
+                              test model
                             </p>
                             <p
                               className="rowDesc"
                             >
-                              How fast should I descent the gradient
+                              A really great model
                             </p>
                           </footer>
                           <div
@@ -6896,129 +5575,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                           <div
                             className="edgeRight"
                             key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                    </div>
-                  </div>
-                </LineageCard>
-                <LineageCard
-                  addSpacer={true}
-                  isTarget={false}
-                  key="1"
-                  rows={
-                    Array [
-                      Object {
-                        "desc": "http://foo.bar/x34s",
-                        "next": true,
-                        "prev": true,
-                        "title": "AWS Webserver",
-                      },
-                      Object {
-                        "desc": "Hosted via GCP",
-                        "prev": true,
-                        "title": "Product API",
-                      },
-                    ]
-                  }
-                  setLineageViewTarget={[Function]}
-                  title="Deployments"
-                  type="artifact"
-                >
-                  <div
-                    className="cardContainer artifact addSpacer"
-                  >
-                    <div
-                      className="cardTitle"
-                    >
-                      <h3>
-                        Deployments
-                      </h3>
-                    </div>
-                    <div
-                      className="cardBody"
-                    >
-                      <LineageCardRow
-                        description="http://foo.bar/x34s"
-                        hideRadio={false}
-                        isLastRow={false}
-                        key="0"
-                        leftAffordance={true}
-                        rightAffordance={true}
-                        setLineageViewTarget={[Function]}
-                        title="AWS Webserver"
-                      >
-                        <div
-                          className="cardRow "
-                        >
-                          <div>
-                            <input
-                              className="form-radio"
-                              name=""
-                              onClick={[Function]}
-                              type="radio"
-                              value=""
-                            />
-                          </div>
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              AWS Webserver
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              http://foo.bar/x34s
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeLeft"
-                            key="edgeLeft"
-                          />
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                      <LineageCardRow
-                        description="Hosted via GCP"
-                        hideRadio={false}
-                        isLastRow={true}
-                        key="1"
-                        leftAffordance={true}
-                        rightAffordance={false}
-                        setLineageViewTarget={[Function]}
-                        title="Product API"
-                      >
-                        <div
-                          className="cardRow lastRow"
-                        >
-                          <div>
-                            <input
-                              className="form-radio"
-                              name=""
-                              onClick={[Function]}
-                              type="radio"
-                              value=""
-                            />
-                          </div>
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              Product API
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              Hosted via GCP
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeLeft"
-                            key="edgeLeft"
                           />
                         </div>
                       </LineageCardRow>
@@ -7912,7 +6468,7 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
     >
       <MD2Tabs
         onSwitch={[Function]}
-        selectedTab={0}
+        selectedTab={1}
         tabs={
           Array [
             "Overview",
@@ -7940,151 +6496,8 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
             />
           </_default>
           <WithStyles(Button)
-            className="button active"
-            key="0"
-            onClick={[Function]}
-          >
-            <Button
-              className="button active"
-              classes={
-                Object {
-                  "colorInherit": "MuiButton-colorInherit-32",
-                  "contained": "MuiButton-contained-22",
-                  "containedPrimary": "MuiButton-containedPrimary-23",
-                  "containedSecondary": "MuiButton-containedSecondary-24",
-                  "disabled": "MuiButton-disabled-31",
-                  "extendedFab": "MuiButton-extendedFab-29",
-                  "fab": "MuiButton-fab-28",
-                  "flat": "MuiButton-flat-16",
-                  "flatPrimary": "MuiButton-flatPrimary-17",
-                  "flatSecondary": "MuiButton-flatSecondary-18",
-                  "focusVisible": "MuiButton-focusVisible-30",
-                  "fullWidth": "MuiButton-fullWidth-36",
-                  "label": "MuiButton-label-12",
-                  "mini": "MuiButton-mini-33",
-                  "outlined": "MuiButton-outlined-19",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-20",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-21",
-                  "raised": "MuiButton-raised-25",
-                  "raisedPrimary": "MuiButton-raisedPrimary-26",
-                  "raisedSecondary": "MuiButton-raisedSecondary-27",
-                  "root": "MuiButton-root-11",
-                  "sizeLarge": "MuiButton-sizeLarge-35",
-                  "sizeSmall": "MuiButton-sizeSmall-34",
-                  "text": "MuiButton-text-13",
-                  "textPrimary": "MuiButton-textPrimary-14",
-                  "textSecondary": "MuiButton-textSecondary-15",
-                }
-              }
-              color="default"
-              component="button"
-              disableFocusRipple={false}
-              disabled={false}
-              fullWidth={false}
-              mini={false}
-              onClick={[Function]}
-              size="medium"
-              type="button"
-              variant="text"
-            >
-              <WithStyles(ButtonBase)
-                className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button active"
-                component="button"
-                disabled={false}
-                focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-30"
-                onClick={[Function]}
-                type="button"
-              >
-                <ButtonBase
-                  centerRipple={false}
-                  className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button active"
-                  classes={
-                    Object {
-                      "disabled": "MuiButtonBase-disabled-38",
-                      "focusVisible": "MuiButtonBase-focusVisible-39",
-                      "root": "MuiButtonBase-root-37",
-                    }
-                  }
-                  component="button"
-                  disableRipple={false}
-                  disableTouchRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-30"
-                  onClick={[Function]}
-                  tabIndex="0"
-                  type="button"
-                >
-                  <button
-                    className="MuiButtonBase-root-37 MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button active"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex="0"
-                    type="button"
-                  >
-                    <span
-                      className="MuiButton-label-12"
-                    >
-                      <span>
-                        Overview
-                      </span>
-                    </span>
-                    <NoSsr
-                      defer={false}
-                      fallback={null}
-                    >
-                      <WithStyles(TouchRipple)
-                        center={false}
-                        innerRef={[Function]}
-                      >
-                        <TouchRipple
-                          center={false}
-                          classes={
-                            Object {
-                              "child": "MuiTouchRipple-child-44",
-                              "childLeaving": "MuiTouchRipple-childLeaving-45",
-                              "childPulsate": "MuiTouchRipple-childPulsate-46",
-                              "ripple": "MuiTouchRipple-ripple-41",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-43",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-42",
-                              "root": "MuiTouchRipple-root-40",
-                            }
-                          }
-                        >
-                          <TransitionGroup
-                            childFactory={[Function]}
-                            className="MuiTouchRipple-root-40"
-                            component="span"
-                            enter={true}
-                            exit={true}
-                          >
-                            <span
-                              className="MuiTouchRipple-root-40"
-                            />
-                          </TransitionGroup>
-                        </TouchRipple>
-                      </WithStyles(TouchRipple)>
-                    </NoSsr>
-                  </button>
-                </ButtonBase>
-              </WithStyles(ButtonBase)>
-            </Button>
-          </WithStyles(Button)>
-          <WithStyles(Button)
             className="button"
-            key="1"
+            key="0"
             onClick={[Function]}
           >
             <Button
@@ -8181,6 +6594,149 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                       className="MuiButton-label-12"
                     >
                       <span>
+                        Overview
+                      </span>
+                    </span>
+                    <NoSsr
+                      defer={false}
+                      fallback={null}
+                    >
+                      <WithStyles(TouchRipple)
+                        center={false}
+                        innerRef={[Function]}
+                      >
+                        <TouchRipple
+                          center={false}
+                          classes={
+                            Object {
+                              "child": "MuiTouchRipple-child-53",
+                              "childLeaving": "MuiTouchRipple-childLeaving-54",
+                              "childPulsate": "MuiTouchRipple-childPulsate-55",
+                              "ripple": "MuiTouchRipple-ripple-50",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-52",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-51",
+                              "root": "MuiTouchRipple-root-49",
+                            }
+                          }
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            className="MuiTouchRipple-root-49"
+                            component="span"
+                            enter={true}
+                            exit={true}
+                          >
+                            <span
+                              className="MuiTouchRipple-root-49"
+                            />
+                          </TransitionGroup>
+                        </TouchRipple>
+                      </WithStyles(TouchRipple)>
+                    </NoSsr>
+                  </button>
+                </ButtonBase>
+              </WithStyles(ButtonBase)>
+            </Button>
+          </WithStyles(Button)>
+          <WithStyles(Button)
+            className="button active"
+            key="1"
+            onClick={[Function]}
+          >
+            <Button
+              className="button active"
+              classes={
+                Object {
+                  "colorInherit": "MuiButton-colorInherit-32",
+                  "contained": "MuiButton-contained-22",
+                  "containedPrimary": "MuiButton-containedPrimary-23",
+                  "containedSecondary": "MuiButton-containedSecondary-24",
+                  "disabled": "MuiButton-disabled-31",
+                  "extendedFab": "MuiButton-extendedFab-29",
+                  "fab": "MuiButton-fab-28",
+                  "flat": "MuiButton-flat-16",
+                  "flatPrimary": "MuiButton-flatPrimary-17",
+                  "flatSecondary": "MuiButton-flatSecondary-18",
+                  "focusVisible": "MuiButton-focusVisible-30",
+                  "fullWidth": "MuiButton-fullWidth-36",
+                  "label": "MuiButton-label-12",
+                  "mini": "MuiButton-mini-33",
+                  "outlined": "MuiButton-outlined-19",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-20",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-21",
+                  "raised": "MuiButton-raised-25",
+                  "raisedPrimary": "MuiButton-raisedPrimary-26",
+                  "raisedSecondary": "MuiButton-raisedSecondary-27",
+                  "root": "MuiButton-root-11",
+                  "sizeLarge": "MuiButton-sizeLarge-35",
+                  "sizeSmall": "MuiButton-sizeSmall-34",
+                  "text": "MuiButton-text-13",
+                  "textPrimary": "MuiButton-textPrimary-14",
+                  "textSecondary": "MuiButton-textSecondary-15",
+                }
+              }
+              color="default"
+              component="button"
+              disableFocusRipple={false}
+              disabled={false}
+              fullWidth={false}
+              mini={false}
+              onClick={[Function]}
+              size="medium"
+              type="button"
+              variant="text"
+            >
+              <WithStyles(ButtonBase)
+                className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button active"
+                component="button"
+                disabled={false}
+                focusRipple={true}
+                focusVisibleClassName="MuiButton-focusVisible-30"
+                onClick={[Function]}
+                type="button"
+              >
+                <ButtonBase
+                  centerRipple={false}
+                  className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button active"
+                  classes={
+                    Object {
+                      "disabled": "MuiButtonBase-disabled-38",
+                      "focusVisible": "MuiButtonBase-focusVisible-39",
+                      "root": "MuiButtonBase-root-37",
+                    }
+                  }
+                  component="button"
+                  disableRipple={false}
+                  disableTouchRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="MuiButton-focusVisible-30"
+                  onClick={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <button
+                    className="MuiButtonBase-root-37 MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button active"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onContextMenu={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <span
+                      className="MuiButton-label-12"
+                    >
+                      <span>
                         Lineage Explorer
                       </span>
                     </span>
@@ -8196,25 +6752,25 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-44",
-                              "childLeaving": "MuiTouchRipple-childLeaving-45",
-                              "childPulsate": "MuiTouchRipple-childPulsate-46",
-                              "ripple": "MuiTouchRipple-ripple-41",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-43",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-42",
-                              "root": "MuiTouchRipple-root-40",
+                              "child": "MuiTouchRipple-child-53",
+                              "childLeaving": "MuiTouchRipple-childLeaving-54",
+                              "childPulsate": "MuiTouchRipple-childPulsate-55",
+                              "ripple": "MuiTouchRipple-ripple-50",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-52",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-51",
+                              "root": "MuiTouchRipple-root-49",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-40"
+                            className="MuiTouchRipple-root-49"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-40"
+                              className="MuiTouchRipple-root-49"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -8228,17 +6784,82 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
         </div>
       </MD2Tabs>
     </div>
-    <div
-      className=""
-    >
-      <ResourceInfo
-        resource={
-          Object {
-            "array": Array [
-              1,
-              1,
-              "gs://my-bucket/mnist",
+    <LineageView
+      target={
+        Object {
+          "array": Array [
+            1,
+            1,
+            "gs://my-bucket/mnist",
+            Array [
               Array [
+                "__ALL_META__",
+                Array [
+                  undefined,
+                  undefined,
+                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                ],
+              ],
+              Array [
+                "create_time",
+                Array [
+                  undefined,
+                  undefined,
+                  "2019-06-12T01:21:48.259263Z",
+                ],
+              ],
+              Array [
+                "description",
+                Array [
+                  undefined,
+                  undefined,
+                  "A really great model",
+                ],
+              ],
+              Array [
+                "name",
+                Array [
+                  undefined,
+                  undefined,
+                  "test model",
+                ],
+              ],
+              Array [
+                "version",
+                Array [
+                  undefined,
+                  undefined,
+                  "v1",
+                ],
+              ],
+            ],
+            Array [
+              Array [
+                "__kf_run__",
+                Array [
+                  undefined,
+                  undefined,
+                  "1",
+                ],
+              ],
+              Array [
+                "__kf_workspace__",
+                Array [
+                  undefined,
+                  undefined,
+                  "workspace-1",
+                ],
+              ],
+            ],
+          ],
+          "arrayIndexOffset_": -1,
+          "convertedPrimitiveFields_": Object {},
+          "messageId_": undefined,
+          "pivot_": 1.7976931348623157e+308,
+          "wrappers_": Object {
+            "4": Object {
+              "arrClean": true,
+              "arr_": Array [
                 Array [
                   "__ALL_META__",
                   Array [
@@ -8280,7 +6901,113 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                   ],
                 ],
               ],
-              Array [
+              "map_": Object {
+                "__ALL_META__": Object {
+                  "key": "__ALL_META__",
+                  "value": Array [
+                    undefined,
+                    undefined,
+                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                  ],
+                  "valueWrapper": Object {
+                    "array": Array [
+                      undefined,
+                      undefined,
+                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                    ],
+                    "arrayIndexOffset_": -1,
+                    "convertedPrimitiveFields_": Object {},
+                    "messageId_": undefined,
+                    "pivot_": 1.7976931348623157e+308,
+                    "wrappers_": null,
+                  },
+                },
+                "create_time": Object {
+                  "key": "create_time",
+                  "value": Array [
+                    undefined,
+                    undefined,
+                    "2019-06-12T01:21:48.259263Z",
+                  ],
+                  "valueWrapper": Object {
+                    "array": Array [
+                      undefined,
+                      undefined,
+                      "2019-06-12T01:21:48.259263Z",
+                    ],
+                    "arrayIndexOffset_": -1,
+                    "convertedPrimitiveFields_": Object {},
+                    "messageId_": undefined,
+                    "pivot_": 1.7976931348623157e+308,
+                    "wrappers_": null,
+                  },
+                },
+                "description": Object {
+                  "key": "description",
+                  "value": Array [
+                    undefined,
+                    undefined,
+                    "A really great model",
+                  ],
+                  "valueWrapper": Object {
+                    "array": Array [
+                      undefined,
+                      undefined,
+                      "A really great model",
+                    ],
+                    "arrayIndexOffset_": -1,
+                    "convertedPrimitiveFields_": Object {},
+                    "messageId_": undefined,
+                    "pivot_": 1.7976931348623157e+308,
+                    "wrappers_": null,
+                  },
+                },
+                "name": Object {
+                  "key": "name",
+                  "value": Array [
+                    undefined,
+                    undefined,
+                    "test model",
+                  ],
+                  "valueWrapper": Object {
+                    "array": Array [
+                      undefined,
+                      undefined,
+                      "test model",
+                    ],
+                    "arrayIndexOffset_": -1,
+                    "convertedPrimitiveFields_": Object {},
+                    "messageId_": undefined,
+                    "pivot_": 1.7976931348623157e+308,
+                    "wrappers_": null,
+                  },
+                },
+                "version": Object {
+                  "key": "version",
+                  "value": Array [
+                    undefined,
+                    undefined,
+                    "v1",
+                  ],
+                  "valueWrapper": Object {
+                    "array": Array [
+                      undefined,
+                      undefined,
+                      "v1",
+                    ],
+                    "arrayIndexOffset_": -1,
+                    "convertedPrimitiveFields_": Object {},
+                    "messageId_": undefined,
+                    "pivot_": 1.7976931348623157e+308,
+                    "wrappers_": null,
+                  },
+                },
+              },
+              "valueCtor_": [Function],
+            },
+            "5": Object {
+              "arrClean": true,
+              "arr_": Array [
                 Array [
                   "__kf_run__",
                   Array [
@@ -8298,15 +7025,65 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                   ],
                 ],
               ],
-            ],
-            "arrayIndexOffset_": -1,
-            "convertedPrimitiveFields_": Object {},
-            "messageId_": undefined,
-            "pivot_": 1.7976931348623157e+308,
-            "wrappers_": Object {
-              "4": Object {
-                "arrClean": true,
-                "arr_": Array [
+              "map_": Object {
+                "__kf_run__": Object {
+                  "key": "__kf_run__",
+                  "value": Array [
+                    undefined,
+                    undefined,
+                    "1",
+                  ],
+                  "valueWrapper": Object {
+                    "array": Array [
+                      undefined,
+                      undefined,
+                      "1",
+                    ],
+                    "arrayIndexOffset_": -1,
+                    "convertedPrimitiveFields_": Object {},
+                    "messageId_": undefined,
+                    "pivot_": 1.7976931348623157e+308,
+                    "wrappers_": null,
+                  },
+                },
+                "__kf_workspace__": Object {
+                  "key": "__kf_workspace__",
+                  "value": Array [
+                    undefined,
+                    undefined,
+                    "workspace-1",
+                  ],
+                  "valueWrapper": Object {
+                    "array": Array [
+                      undefined,
+                      undefined,
+                      "workspace-1",
+                    ],
+                    "arrayIndexOffset_": -1,
+                    "convertedPrimitiveFields_": Object {},
+                    "messageId_": undefined,
+                    "pivot_": 1.7976931348623157e+308,
+                    "wrappers_": null,
+                  },
+                },
+              },
+              "valueCtor_": [Function],
+            },
+          },
+        }
+      }
+    >
+      <div
+        className="page"
+      >
+        <LineageActionBar
+          initialTarget={
+            Object {
+              "array": Array [
+                1,
+                1,
+                "gs://my-bucket/mnist",
+                Array [
                   Array [
                     "__ALL_META__",
                     Array [
@@ -8348,113 +7125,7 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                     ],
                   ],
                 ],
-                "map_": Object {
-                  "__ALL_META__": Object {
-                    "key": "__ALL_META__",
-                    "value": Array [
-                      undefined,
-                      undefined,
-                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                    ],
-                    "valueWrapper": Object {
-                      "array": Array [
-                        undefined,
-                        undefined,
-                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                      ],
-                      "arrayIndexOffset_": -1,
-                      "convertedPrimitiveFields_": Object {},
-                      "messageId_": undefined,
-                      "pivot_": 1.7976931348623157e+308,
-                      "wrappers_": null,
-                    },
-                  },
-                  "create_time": Object {
-                    "key": "create_time",
-                    "value": Array [
-                      undefined,
-                      undefined,
-                      "2019-06-12T01:21:48.259263Z",
-                    ],
-                    "valueWrapper": Object {
-                      "array": Array [
-                        undefined,
-                        undefined,
-                        "2019-06-12T01:21:48.259263Z",
-                      ],
-                      "arrayIndexOffset_": -1,
-                      "convertedPrimitiveFields_": Object {},
-                      "messageId_": undefined,
-                      "pivot_": 1.7976931348623157e+308,
-                      "wrappers_": null,
-                    },
-                  },
-                  "description": Object {
-                    "key": "description",
-                    "value": Array [
-                      undefined,
-                      undefined,
-                      "A really great model",
-                    ],
-                    "valueWrapper": Object {
-                      "array": Array [
-                        undefined,
-                        undefined,
-                        "A really great model",
-                      ],
-                      "arrayIndexOffset_": -1,
-                      "convertedPrimitiveFields_": Object {},
-                      "messageId_": undefined,
-                      "pivot_": 1.7976931348623157e+308,
-                      "wrappers_": null,
-                    },
-                  },
-                  "name": Object {
-                    "key": "name",
-                    "value": Array [
-                      undefined,
-                      undefined,
-                      "test model",
-                    ],
-                    "valueWrapper": Object {
-                      "array": Array [
-                        undefined,
-                        undefined,
-                        "test model",
-                      ],
-                      "arrayIndexOffset_": -1,
-                      "convertedPrimitiveFields_": Object {},
-                      "messageId_": undefined,
-                      "pivot_": 1.7976931348623157e+308,
-                      "wrappers_": null,
-                    },
-                  },
-                  "version": Object {
-                    "key": "version",
-                    "value": Array [
-                      undefined,
-                      undefined,
-                      "v1",
-                    ],
-                    "valueWrapper": Object {
-                      "array": Array [
-                        undefined,
-                        undefined,
-                        "v1",
-                      ],
-                      "arrayIndexOffset_": -1,
-                      "convertedPrimitiveFields_": Object {},
-                      "messageId_": undefined,
-                      "pivot_": 1.7976931348623157e+308,
-                      "wrappers_": null,
-                    },
-                  },
-                },
-                "valueCtor_": [Function],
-              },
-              "5": Object {
-                "arrClean": true,
-                "arr_": Array [
+                Array [
                   Array [
                     "__kf_run__",
                     Array [
@@ -8472,301 +7143,4843 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                     ],
                   ],
                 ],
-                "map_": Object {
-                  "__kf_run__": Object {
-                    "key": "__kf_run__",
-                    "value": Array [
-                      undefined,
-                      undefined,
-                      "1",
+              ],
+              "arrayIndexOffset_": -1,
+              "convertedPrimitiveFields_": Object {},
+              "messageId_": undefined,
+              "pivot_": 1.7976931348623157e+308,
+              "wrappers_": Object {
+                "4": Object {
+                  "arrClean": true,
+                  "arr_": Array [
+                    Array [
+                      "__ALL_META__",
+                      Array [
+                        undefined,
+                        undefined,
+                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                      ],
                     ],
-                    "valueWrapper": Object {
-                      "array": Array [
+                    Array [
+                      "create_time",
+                      Array [
+                        undefined,
+                        undefined,
+                        "2019-06-12T01:21:48.259263Z",
+                      ],
+                    ],
+                    Array [
+                      "description",
+                      Array [
+                        undefined,
+                        undefined,
+                        "A really great model",
+                      ],
+                    ],
+                    Array [
+                      "name",
+                      Array [
+                        undefined,
+                        undefined,
+                        "test model",
+                      ],
+                    ],
+                    Array [
+                      "version",
+                      Array [
+                        undefined,
+                        undefined,
+                        "v1",
+                      ],
+                    ],
+                  ],
+                  "map_": Object {
+                    "__ALL_META__": Object {
+                      "key": "__ALL_META__",
+                      "value": Array [
+                        undefined,
+                        undefined,
+                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                      ],
+                      "valueWrapper": Object {
+                        "array": Array [
+                          undefined,
+                          undefined,
+                          "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": null,
+                      },
+                    },
+                    "create_time": Object {
+                      "key": "create_time",
+                      "value": Array [
+                        undefined,
+                        undefined,
+                        "2019-06-12T01:21:48.259263Z",
+                      ],
+                      "valueWrapper": Object {
+                        "array": Array [
+                          undefined,
+                          undefined,
+                          "2019-06-12T01:21:48.259263Z",
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": null,
+                      },
+                    },
+                    "description": Object {
+                      "key": "description",
+                      "value": Array [
+                        undefined,
+                        undefined,
+                        "A really great model",
+                      ],
+                      "valueWrapper": Object {
+                        "array": Array [
+                          undefined,
+                          undefined,
+                          "A really great model",
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": null,
+                      },
+                    },
+                    "name": Object {
+                      "key": "name",
+                      "value": Array [
+                        undefined,
+                        undefined,
+                        "test model",
+                      ],
+                      "valueWrapper": Object {
+                        "array": Array [
+                          undefined,
+                          undefined,
+                          "test model",
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": null,
+                      },
+                    },
+                    "version": Object {
+                      "key": "version",
+                      "value": Array [
+                        undefined,
+                        undefined,
+                        "v1",
+                      ],
+                      "valueWrapper": Object {
+                        "array": Array [
+                          undefined,
+                          undefined,
+                          "v1",
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": null,
+                      },
+                    },
+                  },
+                  "valueCtor_": [Function],
+                },
+                "5": Object {
+                  "arrClean": true,
+                  "arr_": Array [
+                    Array [
+                      "__kf_run__",
+                      Array [
                         undefined,
                         undefined,
                         "1",
                       ],
-                      "arrayIndexOffset_": -1,
-                      "convertedPrimitiveFields_": Object {},
-                      "messageId_": undefined,
-                      "pivot_": 1.7976931348623157e+308,
-                      "wrappers_": null,
-                    },
-                  },
-                  "__kf_workspace__": Object {
-                    "key": "__kf_workspace__",
-                    "value": Array [
-                      undefined,
-                      undefined,
-                      "workspace-1",
                     ],
-                    "valueWrapper": Object {
-                      "array": Array [
+                    Array [
+                      "__kf_workspace__",
+                      Array [
                         undefined,
                         undefined,
                         "workspace-1",
                       ],
-                      "arrayIndexOffset_": -1,
-                      "convertedPrimitiveFields_": Object {},
-                      "messageId_": undefined,
-                      "pivot_": 1.7976931348623157e+308,
-                      "wrappers_": null,
+                    ],
+                  ],
+                  "map_": Object {
+                    "__kf_run__": Object {
+                      "key": "__kf_run__",
+                      "value": Array [
+                        undefined,
+                        undefined,
+                        "1",
+                      ],
+                      "valueWrapper": Object {
+                        "array": Array [
+                          undefined,
+                          undefined,
+                          "1",
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": null,
+                      },
+                    },
+                    "__kf_workspace__": Object {
+                      "key": "__kf_workspace__",
+                      "value": Array [
+                        undefined,
+                        undefined,
+                        "workspace-1",
+                      ],
+                      "valueWrapper": Object {
+                        "array": Array [
+                          undefined,
+                          undefined,
+                          "workspace-1",
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": null,
+                      },
                     },
                   },
+                  "valueCtor_": [Function],
                 },
-                "valueCtor_": [Function],
               },
-            },
+            }
           }
-        }
-        typeName="Model"
-      >
-        <section>
-          <h1
-            className="header"
-          >
-            Type: 
-            Model
-          </h1>
-          <h2
-            className="header2"
-          >
-            Properties
-          </h2>
-          <dl
-            className="resourceInfo"
+          setLineageViewTarget={[Function]}
+        >
+          <div
+            className="container flex"
           >
             <div
-              className="field"
-              key="create_time"
+              className="flex"
             >
-              <dt
-                className="term"
-              >
-                create_time
-              </dt>
-              <dd
-                className="value"
-              >
-                2019-06-12T01:21:48.259263Z
-              </dd>
-            </div>
-            <div
-              className="field"
-              key="description"
-            >
-              <dt
-                className="term"
-              >
-                description
-              </dt>
-              <dd
-                className="value"
-              >
-                A really great model
-              </dd>
-            </div>
-            <div
-              className="field"
-              key="name"
-            >
-              <dt
-                className="term"
-              >
-                name
-              </dt>
-              <dd
-                className="value"
+              <button
+                className="breadcrumbActive"
+                disabled={true}
+                key="breadcrumb-0"
+                onClick={[Function]}
               >
                 test model
-              </dd>
+              </button>
             </div>
-            <div
-              className="field"
-              key="version"
-            >
-              <dt
-                className="term"
+            <div>
+              <WithStyles(Button)
+                className="actionButton"
+                disabled={false}
+                onClick={[Function]}
               >
-                version
-              </dt>
-              <dd
-                className="value"
-              >
-                v1
-              </dd>
+                <Button
+                  className="actionButton"
+                  classes={
+                    Object {
+                      "colorInherit": "MuiButton-colorInherit-32",
+                      "contained": "MuiButton-contained-22",
+                      "containedPrimary": "MuiButton-containedPrimary-23",
+                      "containedSecondary": "MuiButton-containedSecondary-24",
+                      "disabled": "MuiButton-disabled-31",
+                      "extendedFab": "MuiButton-extendedFab-29",
+                      "fab": "MuiButton-fab-28",
+                      "flat": "MuiButton-flat-16",
+                      "flatPrimary": "MuiButton-flatPrimary-17",
+                      "flatSecondary": "MuiButton-flatSecondary-18",
+                      "focusVisible": "MuiButton-focusVisible-30",
+                      "fullWidth": "MuiButton-fullWidth-36",
+                      "label": "MuiButton-label-12",
+                      "mini": "MuiButton-mini-33",
+                      "outlined": "MuiButton-outlined-19",
+                      "outlinedPrimary": "MuiButton-outlinedPrimary-20",
+                      "outlinedSecondary": "MuiButton-outlinedSecondary-21",
+                      "raised": "MuiButton-raised-25",
+                      "raisedPrimary": "MuiButton-raisedPrimary-26",
+                      "raisedSecondary": "MuiButton-raisedSecondary-27",
+                      "root": "MuiButton-root-11",
+                      "sizeLarge": "MuiButton-sizeLarge-35",
+                      "sizeSmall": "MuiButton-sizeSmall-34",
+                      "text": "MuiButton-text-13",
+                      "textPrimary": "MuiButton-textPrimary-14",
+                      "textSecondary": "MuiButton-textSecondary-15",
+                    }
+                  }
+                  color="default"
+                  component="button"
+                  disableFocusRipple={false}
+                  disabled={false}
+                  fullWidth={false}
+                  mini={false}
+                  onClick={[Function]}
+                  size="medium"
+                  type="button"
+                  variant="text"
+                >
+                  <WithStyles(ButtonBase)
+                    className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 actionButton"
+                    component="button"
+                    disabled={false}
+                    focusRipple={true}
+                    focusVisibleClassName="MuiButton-focusVisible-30"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <ButtonBase
+                      centerRipple={false}
+                      className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 actionButton"
+                      classes={
+                        Object {
+                          "disabled": "MuiButtonBase-disabled-38",
+                          "focusVisible": "MuiButtonBase-focusVisible-39",
+                          "root": "MuiButtonBase-root-37",
+                        }
+                      }
+                      component="button"
+                      disableRipple={false}
+                      disableTouchRipple={false}
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-30"
+                      onClick={[Function]}
+                      tabIndex="0"
+                      type="button"
+                    >
+                      <button
+                        className="MuiButtonBase-root-37 MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 actionButton"
+                        disabled={false}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onContextMenu={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyUp={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <span
+                          className="MuiButton-label-12"
+                        >
+                          <pure(ReplayIcon)>
+                            <ReplayIcon>
+                              <WithStyles(SvgIcon)>
+                                <SvgIcon
+                                  classes={
+                                    Object {
+                                      "colorAction": "MuiSvgIcon-colorAction-43",
+                                      "colorDisabled": "MuiSvgIcon-colorDisabled-45",
+                                      "colorError": "MuiSvgIcon-colorError-44",
+                                      "colorPrimary": "MuiSvgIcon-colorPrimary-41",
+                                      "colorSecondary": "MuiSvgIcon-colorSecondary-42",
+                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-46",
+                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-48",
+                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-47",
+                                      "root": "MuiSvgIcon-root-40",
+                                    }
+                                  }
+                                  color="inherit"
+                                  component="svg"
+                                  fontSize="default"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    className="MuiSvgIcon-root-40"
+                                    focusable="false"
+                                    role="presentation"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M0 0h24v24H0z"
+                                      fill="none"
+                                    />
+                                    <path
+                                      d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+                                    />
+                                  </svg>
+                                </SvgIcon>
+                              </WithStyles(SvgIcon)>
+                            </ReplayIcon>
+                          </pure(ReplayIcon)>
+                           Reset
+                        </span>
+                        <NoSsr
+                          defer={false}
+                          fallback={null}
+                        >
+                          <WithStyles(TouchRipple)
+                            center={false}
+                            innerRef={[Function]}
+                          >
+                            <TouchRipple
+                              center={false}
+                              classes={
+                                Object {
+                                  "child": "MuiTouchRipple-child-53",
+                                  "childLeaving": "MuiTouchRipple-childLeaving-54",
+                                  "childPulsate": "MuiTouchRipple-childPulsate-55",
+                                  "ripple": "MuiTouchRipple-ripple-50",
+                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-52",
+                                  "rippleVisible": "MuiTouchRipple-rippleVisible-51",
+                                  "root": "MuiTouchRipple-root-49",
+                                }
+                              }
+                            >
+                              <TransitionGroup
+                                childFactory={[Function]}
+                                className="MuiTouchRipple-root-49"
+                                component="span"
+                                enter={true}
+                                exit={true}
+                              >
+                                <span
+                                  className="MuiTouchRipple-root-49"
+                                />
+                              </TransitionGroup>
+                            </TouchRipple>
+                          </WithStyles(TouchRipple)>
+                        </NoSsr>
+                      </button>
+                    </ButtonBase>
+                  </WithStyles(ButtonBase)>
+                </Button>
+              </WithStyles(Button)>
             </div>
-          </dl>
-          <h2
-            className="header2"
-          >
-            Custom Properties
-          </h2>
-          <dl
-            className="resourceInfo"
-          >
-            <div
-              className="field"
-              key="__kf_run__"
-            >
-              <dt
-                className="term"
-              >
-                __kf_run__
-              </dt>
-              <dd
-                className="value"
-              >
-                1
-              </dd>
-            </div>
-            <div
-              className="field"
-              key="__kf_workspace__"
-            >
-              <dt
-                className="term"
-              >
-                __kf_workspace__
-              </dt>
-              <dd
-                className="value"
-              >
-                workspace-1
-              </dd>
-            </div>
-          </dl>
-        </section>
-      </ResourceInfo>
-    </div>
-  </div>
-</ArtifactDetails>
-`;
-
-exports[`ArtifactDetails Shows error when returned Artifact is empty 1`] = `
-<ArtifactDetails
-  history={
-    Object {
-      "push": [MockFunction],
-    }
-  }
-  location={Object {}}
-  match={
-    Object {
-      "params": Object {
-        "artifactType": "kubeflow.org/alpha/model",
-        "id": "1",
-      },
-    }
-  }
-  toolbarProps={
-    Object {
-      "actions": Array [],
-      "breadcrumbs": Array [
-        Object {
-          "displayName": "Artifacts",
-          "href": "/artifacts",
-        },
-      ],
-      "pageTitle": "Model 1 details",
-    }
-  }
-  updateBanner={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          Object {
-            "additionalInfo": undefined,
-            "message": "No kubeflow.org/alpha/model identified by id: 1",
-            "mode": "error",
-            "refresh": [Function],
-          },
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": undefined,
-        },
-      ],
-    }
-  }
-  updateDialog={[MockFunction]}
-  updateSnackbar={[MockFunction]}
-  updateToolbar={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          Object {
-            "actions": Array [],
-            "breadcrumbs": Array [
-              Object {
-                "displayName": "Artifacts",
-                "href": "/artifacts",
-              },
-            ],
-            "pageTitle": "Model 1 details",
-          },
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": undefined,
-        },
-      ],
-    }
-  }
->
-  <WithStyles(CircularProgress)>
-    <CircularProgress
-      classes={
-        Object {
-          "circle": "MuiCircularProgress-circle-62",
-          "circleDisableShrink": "MuiCircularProgress-circleDisableShrink-65",
-          "circleIndeterminate": "MuiCircularProgress-circleIndeterminate-64",
-          "circleStatic": "MuiCircularProgress-circleStatic-63",
-          "colorPrimary": "MuiCircularProgress-colorPrimary-59",
-          "colorSecondary": "MuiCircularProgress-colorSecondary-60",
-          "indeterminate": "MuiCircularProgress-indeterminate-58",
-          "root": "MuiCircularProgress-root-56",
-          "static": "MuiCircularProgress-static-57",
-          "svg": "MuiCircularProgress-svg-61",
-        }
-      }
-      color="primary"
-      disableShrink={false}
-      size={40}
-      thickness={3.6}
-      value={0}
-      variant="indeterminate"
-    >
-      <div
-        className="MuiCircularProgress-root-56 MuiCircularProgress-colorPrimary-59 MuiCircularProgress-indeterminate-58"
-        role="progressbar"
-        style={
-          Object {
-            "height": 40,
-            "width": 40,
+          </div>
+        </LineageActionBar>
+        <div
+          className="page LineageExplorer"
+          style={
+            Object {
+              "background": "#f3f2f4",
+              "flexFlow": "row",
+              "overflow": "auto",
+              "position": "relative",
+              "width": "100%",
+              "zIndex": 0,
+            }
           }
-        }
-      >
-        <svg
-          className="MuiCircularProgress-svg-61"
-          viewBox="22 22 44 44"
         >
-          <circle
-            className="MuiCircularProgress-circle-62 MuiCircularProgress-circleIndeterminate-64"
-            cx={44}
-            cy={44}
-            fill="none"
-            r={20.2}
-            strokeWidth={3.6}
-            style={Object {}}
-          />
-        </svg>
+          <LineageCardColumn
+            cards={
+              Array [
+                Object {
+                  "elements": Array [
+                    Object {
+                      "artifact": Object {
+                        "array": Array [
+                          1,
+                          1,
+                          "gs://my-bucket/mnist",
+                          Array [
+                            Array [
+                              "__ALL_META__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                              ],
+                            ],
+                            Array [
+                              "create_time",
+                              Array [
+                                undefined,
+                                undefined,
+                                "2019-06-12T01:21:48.259263Z",
+                              ],
+                            ],
+                            Array [
+                              "description",
+                              Array [
+                                undefined,
+                                undefined,
+                                "A really great model",
+                              ],
+                            ],
+                            Array [
+                              "name",
+                              Array [
+                                undefined,
+                                undefined,
+                                "test model",
+                              ],
+                            ],
+                            Array [
+                              "version",
+                              Array [
+                                undefined,
+                                undefined,
+                                "v1",
+                              ],
+                            ],
+                          ],
+                          Array [
+                            Array [
+                              "__kf_run__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "1",
+                              ],
+                            ],
+                            Array [
+                              "__kf_workspace__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "workspace-1",
+                              ],
+                            ],
+                          ],
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": Object {
+                          "4": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__ALL_META__": Object {
+                                "key": "__ALL_META__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "create_time": Object {
+                                "key": "create_time",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "description": Object {
+                                "key": "description",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "name": Object {
+                                "key": "name",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "version": Object {
+                                "key": "version",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                          "5": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__kf_run__": Object {
+                                "key": "__kf_run__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "__kf_workspace__": Object {
+                                "key": "__kf_workspace__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                        },
+                      },
+                      "desc": "A really great model",
+                      "next": true,
+                      "prev": true,
+                      "title": "test model",
+                    },
+                  ],
+                  "title": "Artifact",
+                },
+              ]
+            }
+            setLineageViewTarget={[Function]}
+            title="Input Artifact"
+            type="artifact"
+          >
+            <div
+              className="mainColumn artifact"
+            >
+              <div
+                className="columnHeader"
+              >
+                <h2>
+                  Input Artifact
+                </h2>
+              </div>
+              <div
+                className="columnBody"
+              >
+                <EdgeCanvas
+                  cardArray={
+                    Array [
+                      1,
+                    ]
+                  }
+                  reverseEdges={false}
+                  type="artifact"
+                >
+                  <div
+                    className="edgeCanvas"
+                  >
+                    <LineChart
+                      areaVisible={false}
+                      axisColor="#34495e"
+                      axisOpacity={0.3}
+                      axisVisible={false}
+                      axisWidth={1}
+                      data={
+                        Array [
+                          Object {
+                            "x": 0,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 30,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 170,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 200,
+                            "y": 0,
+                          },
+                        ]
+                      }
+                      getX={[Function]}
+                      getY={[Function]}
+                      gridColor="#34495e"
+                      gridOpacity={0.2}
+                      gridVisible={false}
+                      gridWidth={1}
+                      key="0-0"
+                      labelsCharacterWidth={10}
+                      labelsColor="#bdc3c7"
+                      labelsCountY={5}
+                      labelsFormatX={[Function]}
+                      labelsFormatY={[Function]}
+                      labelsHeightX={12}
+                      labelsOffsetX={15}
+                      labelsOffsetY={15}
+                      labelsStepX={2}
+                      labelsVisible={false}
+                      pathColor="#BDC1C6"
+                      pathOpacity={1}
+                      pathSmoothing={0}
+                      pathVisible={true}
+                      pathWidth={1}
+                      pointsColor="#fff"
+                      pointsIsHoverOnZone={false}
+                      pointsOnHover={[Function]}
+                      pointsRadius={4}
+                      pointsStrokeColor="#34495e"
+                      pointsStrokeWidth={2}
+                      pointsVisible={false}
+                      viewBoxHeight={1}
+                      viewBoxWidth={200}
+                    >
+                      <styled.svg
+                        viewBox="0 0 200 1"
+                      >
+                        <svg
+                          className="sc-gzVnrw kWKfgJ"
+                          viewBox="0 0 200 1"
+                        >
+                          <g
+                            transform="translate(0, 0)"
+                          >
+                            <Grid
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Path
+                              areaColor="#34495e"
+                              areaOpacity={0.5}
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            >
+                              <g>
+                                <styled.path
+                                  color="#BDC1C6"
+                                  d="M 0 1  C
+      0
+      1
+      0
+      1
+      5
+      1
+      C
+      10
+      1
+      20
+      1
+      48.33
+      1
+      C
+      76.67
+      1
+      123.33
+      1
+      151.67
+      1
+     C
+      180
+      1
+      190
+      1
+      195
+      1
+    L 200 1 "
+                                  opacity={1}
+                                  width={1}
+                                >
+                                  <path
+                                    className="sc-htpNat emMQTt"
+                                    color="#BDC1C6"
+                                    d="M 0 1  C
+      0
+      1
+      0
+      1
+      5
+      1
+      C
+      10
+      1
+      20
+      1
+      48.33
+      1
+      C
+      76.67
+      1
+      123.33
+      1
+      151.67
+      1
+     C
+      180
+      1
+      190
+      1
+      195
+      1
+    L 200 1 "
+                                    opacity={1}
+                                    width={1}
+                                  />
+                                </styled.path>
+                              </g>
+                            </Path>
+                            <Axis
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Points
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Labels
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                          </g>
+                        </svg>
+                      </styled.svg>
+                    </LineChart>
+                  </div>
+                </EdgeCanvas>
+                <LineageCard
+                  addSpacer={false}
+                  isTarget={false}
+                  key="0"
+                  rows={
+                    Array [
+                      Object {
+                        "artifact": Object {
+                          "array": Array [
+                            1,
+                            1,
+                            "gs://my-bucket/mnist",
+                            Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                          ],
+                          "arrayIndexOffset_": -1,
+                          "convertedPrimitiveFields_": Object {},
+                          "messageId_": undefined,
+                          "pivot_": 1.7976931348623157e+308,
+                          "wrappers_": Object {
+                            "4": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__ALL_META__": Object {
+                                  "key": "__ALL_META__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "create_time": Object {
+                                  "key": "create_time",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "description": Object {
+                                  "key": "description",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "name": Object {
+                                  "key": "name",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "version": Object {
+                                  "key": "version",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                            "5": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__kf_run__": Object {
+                                  "key": "__kf_run__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "__kf_workspace__": Object {
+                                  "key": "__kf_workspace__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                          },
+                        },
+                        "desc": "A really great model",
+                        "next": true,
+                        "prev": true,
+                        "title": "test model",
+                      },
+                    ]
+                  }
+                  setLineageViewTarget={[Function]}
+                  title="Artifact"
+                  type="artifact"
+                >
+                  <div
+                    className="cardContainer artifact"
+                  >
+                    <div
+                      className="cardTitle"
+                    >
+                      <h3>
+                        Artifact
+                      </h3>
+                    </div>
+                    <div
+                      className="cardBody"
+                    >
+                      <LineageCardRow
+                        artifact={
+                          Object {
+                            "array": Array [
+                              1,
+                              1,
+                              "gs://my-bucket/mnist",
+                              Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                            ],
+                            "arrayIndexOffset_": -1,
+                            "convertedPrimitiveFields_": Object {},
+                            "messageId_": undefined,
+                            "pivot_": 1.7976931348623157e+308,
+                            "wrappers_": Object {
+                              "4": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__ALL_META__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                  ],
+                                  Array [
+                                    "create_time",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                  ],
+                                  Array [
+                                    "description",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "name",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "version",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__ALL_META__": Object {
+                                    "key": "__ALL_META__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "create_time": Object {
+                                    "key": "create_time",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "2019-06-12T01:21:48.259263Z",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "description": Object {
+                                    "key": "description",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "A really great model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "name": Object {
+                                    "key": "name",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "test model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "version": Object {
+                                    "key": "version",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "v1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                              "5": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__kf_run__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                  ],
+                                  Array [
+                                    "__kf_workspace__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__kf_run__": Object {
+                                    "key": "__kf_run__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "__kf_workspace__": Object {
+                                    "key": "__kf_workspace__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "workspace-1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                            },
+                          }
+                        }
+                        description="A really great model"
+                        hideRadio={false}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        rightAffordance={true}
+                        setLineageViewTarget={[Function]}
+                        title="test model"
+                      >
+                        <div
+                          className="cardRow lastRow"
+                        >
+                          <div>
+                            <input
+                              className="form-radio"
+                              name=""
+                              onClick={[Function]}
+                              type="radio"
+                              value=""
+                            />
+                          </div>
+                          <footer>
+                            <p
+                              className="rowTitle"
+                            >
+                              test model
+                            </p>
+                            <p
+                              className="rowDesc"
+                            >
+                              A really great model
+                            </p>
+                          </footer>
+                          <div
+                            className="edgeLeft"
+                            key="edgeLeft"
+                          />
+                          <div
+                            className="edgeRight"
+                            key="edgeRight"
+                          />
+                        </div>
+                      </LineageCardRow>
+                    </div>
+                  </div>
+                </LineageCard>
+              </div>
+            </div>
+          </LineageCardColumn>
+          <LineageCardColumn
+            cards={
+              Array [
+                Object {
+                  "elements": Array [],
+                  "title": "Execution",
+                },
+              ]
+            }
+            title=""
+            type="execution"
+          >
+            <div
+              className="mainColumn execution"
+            >
+              <div
+                className="columnHeader"
+              >
+                <h2 />
+              </div>
+              <div
+                className="columnBody"
+              >
+                <EdgeCanvas
+                  cardArray={
+                    Array [
+                      0,
+                    ]
+                  }
+                  reverseEdges={false}
+                  type="execution"
+                >
+                  <div
+                    className="edgeCanvas"
+                  />
+                </EdgeCanvas>
+                <LineageCard
+                  addSpacer={false}
+                  isTarget={false}
+                  key="0"
+                  rows={Array []}
+                  title="Execution"
+                  type="execution"
+                >
+                  <div
+                    className="cardContainer execution"
+                  >
+                    <div
+                      className="cardTitle"
+                    >
+                      <h3>
+                        Execution
+                      </h3>
+                    </div>
+                    <div
+                      className="cardBody"
+                    />
+                  </div>
+                </LineageCard>
+              </div>
+            </div>
+          </LineageCardColumn>
+          <LineageCardColumn
+            cards={
+              Array [
+                Object {
+                  "elements": Array [
+                    Object {
+                      "artifact": Object {
+                        "array": Array [
+                          1,
+                          1,
+                          "gs://my-bucket/mnist",
+                          Array [
+                            Array [
+                              "__ALL_META__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                              ],
+                            ],
+                            Array [
+                              "create_time",
+                              Array [
+                                undefined,
+                                undefined,
+                                "2019-06-12T01:21:48.259263Z",
+                              ],
+                            ],
+                            Array [
+                              "description",
+                              Array [
+                                undefined,
+                                undefined,
+                                "A really great model",
+                              ],
+                            ],
+                            Array [
+                              "name",
+                              Array [
+                                undefined,
+                                undefined,
+                                "test model",
+                              ],
+                            ],
+                            Array [
+                              "version",
+                              Array [
+                                undefined,
+                                undefined,
+                                "v1",
+                              ],
+                            ],
+                          ],
+                          Array [
+                            Array [
+                              "__kf_run__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "1",
+                              ],
+                            ],
+                            Array [
+                              "__kf_workspace__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "workspace-1",
+                              ],
+                            ],
+                          ],
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": Object {
+                          "4": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__ALL_META__": Object {
+                                "key": "__ALL_META__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "create_time": Object {
+                                "key": "create_time",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "description": Object {
+                                "key": "description",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "name": Object {
+                                "key": "name",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "version": Object {
+                                "key": "version",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                          "5": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__kf_run__": Object {
+                                "key": "__kf_run__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "__kf_workspace__": Object {
+                                "key": "__kf_workspace__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                        },
+                      },
+                      "desc": "A really great model",
+                      "next": true,
+                      "prev": true,
+                      "title": "test model",
+                    },
+                  ],
+                  "title": "Artifact",
+                },
+              ]
+            }
+            title="Target"
+            type="artifact"
+          >
+            <div
+              className="mainColumn artifact"
+            >
+              <div
+                className="columnHeader"
+              >
+                <h2>
+                  Target
+                </h2>
+              </div>
+              <div
+                className="columnBody"
+              >
+                <EdgeCanvas
+                  cardArray={
+                    Array [
+                      1,
+                    ]
+                  }
+                  reverseEdges={false}
+                  type="artifact"
+                >
+                  <div
+                    className="edgeCanvas"
+                  >
+                    <LineChart
+                      areaVisible={false}
+                      axisColor="#34495e"
+                      axisOpacity={0.3}
+                      axisVisible={false}
+                      axisWidth={1}
+                      data={
+                        Array [
+                          Object {
+                            "x": 0,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 30,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 170,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 200,
+                            "y": 0,
+                          },
+                        ]
+                      }
+                      getX={[Function]}
+                      getY={[Function]}
+                      gridColor="#34495e"
+                      gridOpacity={0.2}
+                      gridVisible={false}
+                      gridWidth={1}
+                      key="0-0"
+                      labelsCharacterWidth={10}
+                      labelsColor="#bdc3c7"
+                      labelsCountY={5}
+                      labelsFormatX={[Function]}
+                      labelsFormatY={[Function]}
+                      labelsHeightX={12}
+                      labelsOffsetX={15}
+                      labelsOffsetY={15}
+                      labelsStepX={2}
+                      labelsVisible={false}
+                      pathColor="#BDC1C6"
+                      pathOpacity={1}
+                      pathSmoothing={0}
+                      pathVisible={true}
+                      pathWidth={1}
+                      pointsColor="#fff"
+                      pointsIsHoverOnZone={false}
+                      pointsOnHover={[Function]}
+                      pointsRadius={4}
+                      pointsStrokeColor="#34495e"
+                      pointsStrokeWidth={2}
+                      pointsVisible={false}
+                      viewBoxHeight={1}
+                      viewBoxWidth={200}
+                    >
+                      <styled.svg
+                        viewBox="0 0 200 1"
+                      >
+                        <svg
+                          className="sc-gzVnrw kWKfgJ"
+                          viewBox="0 0 200 1"
+                        >
+                          <g
+                            transform="translate(0, 0)"
+                          >
+                            <Grid
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Path
+                              areaColor="#34495e"
+                              areaOpacity={0.5}
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            >
+                              <g>
+                                <styled.path
+                                  color="#BDC1C6"
+                                  d="M 0 1  C
+      0
+      1
+      0
+      1
+      5
+      1
+      C
+      10
+      1
+      20
+      1
+      48.33
+      1
+      C
+      76.67
+      1
+      123.33
+      1
+      151.67
+      1
+     C
+      180
+      1
+      190
+      1
+      195
+      1
+    L 200 1 "
+                                  opacity={1}
+                                  width={1}
+                                >
+                                  <path
+                                    className="sc-htpNat emMQTt"
+                                    color="#BDC1C6"
+                                    d="M 0 1  C
+      0
+      1
+      0
+      1
+      5
+      1
+      C
+      10
+      1
+      20
+      1
+      48.33
+      1
+      C
+      76.67
+      1
+      123.33
+      1
+      151.67
+      1
+     C
+      180
+      1
+      190
+      1
+      195
+      1
+    L 200 1 "
+                                    opacity={1}
+                                    width={1}
+                                  />
+                                </styled.path>
+                              </g>
+                            </Path>
+                            <Axis
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Points
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Labels
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                          </g>
+                        </svg>
+                      </styled.svg>
+                    </LineChart>
+                  </div>
+                </EdgeCanvas>
+                <LineageCard
+                  addSpacer={false}
+                  isTarget={true}
+                  key="0"
+                  rows={
+                    Array [
+                      Object {
+                        "artifact": Object {
+                          "array": Array [
+                            1,
+                            1,
+                            "gs://my-bucket/mnist",
+                            Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                          ],
+                          "arrayIndexOffset_": -1,
+                          "convertedPrimitiveFields_": Object {},
+                          "messageId_": undefined,
+                          "pivot_": 1.7976931348623157e+308,
+                          "wrappers_": Object {
+                            "4": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__ALL_META__": Object {
+                                  "key": "__ALL_META__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "create_time": Object {
+                                  "key": "create_time",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "description": Object {
+                                  "key": "description",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "name": Object {
+                                  "key": "name",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "version": Object {
+                                  "key": "version",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                            "5": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__kf_run__": Object {
+                                  "key": "__kf_run__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "__kf_workspace__": Object {
+                                  "key": "__kf_workspace__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                          },
+                        },
+                        "desc": "A really great model",
+                        "next": true,
+                        "prev": true,
+                        "title": "test model",
+                      },
+                    ]
+                  }
+                  title="Artifact"
+                  type="artifact"
+                >
+                  <div
+                    className="cardContainer artifact target"
+                  >
+                    <div
+                      className="cardTitle"
+                    >
+                      <h3>
+                        Artifact
+                      </h3>
+                    </div>
+                    <div
+                      className="cardBody"
+                    >
+                      <LineageCardRow
+                        artifact={
+                          Object {
+                            "array": Array [
+                              1,
+                              1,
+                              "gs://my-bucket/mnist",
+                              Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                            ],
+                            "arrayIndexOffset_": -1,
+                            "convertedPrimitiveFields_": Object {},
+                            "messageId_": undefined,
+                            "pivot_": 1.7976931348623157e+308,
+                            "wrappers_": Object {
+                              "4": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__ALL_META__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                  ],
+                                  Array [
+                                    "create_time",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                  ],
+                                  Array [
+                                    "description",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "name",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "version",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__ALL_META__": Object {
+                                    "key": "__ALL_META__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "create_time": Object {
+                                    "key": "create_time",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "2019-06-12T01:21:48.259263Z",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "description": Object {
+                                    "key": "description",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "A really great model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "name": Object {
+                                    "key": "name",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "test model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "version": Object {
+                                    "key": "version",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "v1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                              "5": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__kf_run__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                  ],
+                                  Array [
+                                    "__kf_workspace__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__kf_run__": Object {
+                                    "key": "__kf_run__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "__kf_workspace__": Object {
+                                    "key": "__kf_workspace__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "workspace-1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                            },
+                          }
+                        }
+                        description="A really great model"
+                        hideRadio={true}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        rightAffordance={true}
+                        title="test model"
+                      >
+                        <div
+                          className="cardRow lastRow"
+                        >
+                          <div
+                            className="noRadio"
+                          />
+                          <footer>
+                            <p
+                              className="rowTitle"
+                            >
+                              test model
+                            </p>
+                            <p
+                              className="rowDesc"
+                            >
+                              A really great model
+                            </p>
+                          </footer>
+                          <div
+                            className="edgeLeft"
+                            key="edgeLeft"
+                          />
+                          <div
+                            className="edgeRight"
+                            key="edgeRight"
+                          />
+                        </div>
+                      </LineageCardRow>
+                    </div>
+                  </div>
+                </LineageCard>
+              </div>
+            </div>
+          </LineageCardColumn>
+          <LineageCardColumn
+            cards={
+              Array [
+                Object {
+                  "elements": Array [],
+                  "title": "Execution",
+                },
+              ]
+            }
+            title=""
+            type="execution"
+          >
+            <div
+              className="mainColumn execution"
+            >
+              <div
+                className="columnHeader"
+              >
+                <h2 />
+              </div>
+              <div
+                className="columnBody"
+              >
+                <EdgeCanvas
+                  cardArray={
+                    Array [
+                      0,
+                    ]
+                  }
+                  reverseEdges={false}
+                  type="execution"
+                >
+                  <div
+                    className="edgeCanvas"
+                  />
+                </EdgeCanvas>
+                <LineageCard
+                  addSpacer={false}
+                  isTarget={false}
+                  key="0"
+                  rows={Array []}
+                  title="Execution"
+                  type="execution"
+                >
+                  <div
+                    className="cardContainer execution"
+                  >
+                    <div
+                      className="cardTitle"
+                    >
+                      <h3>
+                        Execution
+                      </h3>
+                    </div>
+                    <div
+                      className="cardBody"
+                    />
+                  </div>
+                </LineageCard>
+              </div>
+            </div>
+          </LineageCardColumn>
+          <LineageCardColumn
+            cards={
+              Array [
+                Object {
+                  "elements": Array [
+                    Object {
+                      "artifact": Object {
+                        "array": Array [
+                          1,
+                          1,
+                          "gs://my-bucket/mnist",
+                          Array [
+                            Array [
+                              "__ALL_META__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                              ],
+                            ],
+                            Array [
+                              "create_time",
+                              Array [
+                                undefined,
+                                undefined,
+                                "2019-06-12T01:21:48.259263Z",
+                              ],
+                            ],
+                            Array [
+                              "description",
+                              Array [
+                                undefined,
+                                undefined,
+                                "A really great model",
+                              ],
+                            ],
+                            Array [
+                              "name",
+                              Array [
+                                undefined,
+                                undefined,
+                                "test model",
+                              ],
+                            ],
+                            Array [
+                              "version",
+                              Array [
+                                undefined,
+                                undefined,
+                                "v1",
+                              ],
+                            ],
+                          ],
+                          Array [
+                            Array [
+                              "__kf_run__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "1",
+                              ],
+                            ],
+                            Array [
+                              "__kf_workspace__",
+                              Array [
+                                undefined,
+                                undefined,
+                                "workspace-1",
+                              ],
+                            ],
+                          ],
+                        ],
+                        "arrayIndexOffset_": -1,
+                        "convertedPrimitiveFields_": Object {},
+                        "messageId_": undefined,
+                        "pivot_": 1.7976931348623157e+308,
+                        "wrappers_": Object {
+                          "4": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__ALL_META__": Object {
+                                "key": "__ALL_META__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "create_time": Object {
+                                "key": "create_time",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "description": Object {
+                                "key": "description",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "name": Object {
+                                "key": "name",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "version": Object {
+                                "key": "version",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                          "5": Object {
+                            "arrClean": true,
+                            "arr_": Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                            "map_": Object {
+                              "__kf_run__": Object {
+                                "key": "__kf_run__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                              "__kf_workspace__": Object {
+                                "key": "__kf_workspace__",
+                                "value": Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                                "valueWrapper": Object {
+                                  "array": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "arrayIndexOffset_": -1,
+                                  "convertedPrimitiveFields_": Object {},
+                                  "messageId_": undefined,
+                                  "pivot_": 1.7976931348623157e+308,
+                                  "wrappers_": null,
+                                },
+                              },
+                            },
+                            "valueCtor_": [Function],
+                          },
+                        },
+                      },
+                      "desc": "A really great model",
+                      "next": true,
+                      "prev": true,
+                      "title": "test model",
+                    },
+                  ],
+                  "title": "Artifact",
+                },
+              ]
+            }
+            reverseBindings={true}
+            setLineageViewTarget={[Function]}
+            title="Output Artifact"
+            type="artifact"
+          >
+            <div
+              className="mainColumn artifact"
+            >
+              <div
+                className="columnHeader"
+              >
+                <h2>
+                  Output Artifact
+                </h2>
+              </div>
+              <div
+                className="columnBody"
+              >
+                <EdgeCanvas
+                  cardArray={
+                    Array [
+                      1,
+                    ]
+                  }
+                  reverseEdges={true}
+                  type="artifact"
+                >
+                  <div
+                    className="edgeCanvas edgeCanvasReverse"
+                  >
+                    <LineChart
+                      areaVisible={false}
+                      axisColor="#34495e"
+                      axisOpacity={0.3}
+                      axisVisible={false}
+                      axisWidth={1}
+                      data={
+                        Array [
+                          Object {
+                            "x": 0,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 30,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 170,
+                            "y": 0,
+                          },
+                          Object {
+                            "x": 200,
+                            "y": 0,
+                          },
+                        ]
+                      }
+                      getX={[Function]}
+                      getY={[Function]}
+                      gridColor="#34495e"
+                      gridOpacity={0.2}
+                      gridVisible={false}
+                      gridWidth={1}
+                      key="0-0"
+                      labelsCharacterWidth={10}
+                      labelsColor="#bdc3c7"
+                      labelsCountY={5}
+                      labelsFormatX={[Function]}
+                      labelsFormatY={[Function]}
+                      labelsHeightX={12}
+                      labelsOffsetX={15}
+                      labelsOffsetY={15}
+                      labelsStepX={2}
+                      labelsVisible={false}
+                      pathColor="#BDC1C6"
+                      pathOpacity={1}
+                      pathSmoothing={0}
+                      pathVisible={true}
+                      pathWidth={1}
+                      pointsColor="#fff"
+                      pointsIsHoverOnZone={false}
+                      pointsOnHover={[Function]}
+                      pointsRadius={4}
+                      pointsStrokeColor="#34495e"
+                      pointsStrokeWidth={2}
+                      pointsVisible={false}
+                      viewBoxHeight={1}
+                      viewBoxWidth={200}
+                    >
+                      <styled.svg
+                        viewBox="0 0 200 1"
+                      >
+                        <svg
+                          className="sc-gzVnrw kWKfgJ"
+                          viewBox="0 0 200 1"
+                        >
+                          <g
+                            transform="translate(0, 0)"
+                          >
+                            <Grid
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Path
+                              areaColor="#34495e"
+                              areaOpacity={0.5}
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            >
+                              <g>
+                                <styled.path
+                                  color="#BDC1C6"
+                                  d="M 0 1  C
+      0
+      1
+      0
+      1
+      5
+      1
+      C
+      10
+      1
+      20
+      1
+      48.33
+      1
+      C
+      76.67
+      1
+      123.33
+      1
+      151.67
+      1
+     C
+      180
+      1
+      190
+      1
+      195
+      1
+    L 200 1 "
+                                  opacity={1}
+                                  width={1}
+                                >
+                                  <path
+                                    className="sc-htpNat emMQTt"
+                                    color="#BDC1C6"
+                                    d="M 0 1  C
+      0
+      1
+      0
+      1
+      5
+      1
+      C
+      10
+      1
+      20
+      1
+      48.33
+      1
+      C
+      76.67
+      1
+      123.33
+      1
+      151.67
+      1
+     C
+      180
+      1
+      190
+      1
+      195
+      1
+    L 200 1 "
+                                    opacity={1}
+                                    width={1}
+                                  />
+                                </styled.path>
+                              </g>
+                            </Path>
+                            <Axis
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Points
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                            <Labels
+                              areaVisible={false}
+                              axisColor="#34495e"
+                              axisOpacity={0.3}
+                              axisVisible={false}
+                              axisWidth={1}
+                              data={
+                                Array [
+                                  Object {
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 30,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 170,
+                                    "y": 0,
+                                  },
+                                  Object {
+                                    "x": 200,
+                                    "y": 0,
+                                  },
+                                ]
+                              }
+                              getX={[Function]}
+                              getY={[Function]}
+                              gridColor="#34495e"
+                              gridOpacity={0.2}
+                              gridVisible={false}
+                              gridWidth={1}
+                              labelsCharacterWidth={10}
+                              labelsColor="#bdc3c7"
+                              labelsCountY={5}
+                              labelsFormatX={[Function]}
+                              labelsFormatY={[Function]}
+                              labelsHeightX={12}
+                              labelsOffsetX={15}
+                              labelsOffsetY={15}
+                              labelsStepX={2}
+                              labelsVisible={false}
+                              maxX={200}
+                              maxY={5}
+                              minX={0}
+                              minY={0}
+                              pathColor="#BDC1C6"
+                              pathOpacity={1}
+                              pathSmoothing={0}
+                              pathVisible={true}
+                              pathWidth={1}
+                              pointsColor="#fff"
+                              pointsIsHoverOnZone={false}
+                              pointsOnHover={[Function]}
+                              pointsRadius={4}
+                              pointsStrokeColor="#34495e"
+                              pointsStrokeWidth={2}
+                              pointsVisible={false}
+                            />
+                          </g>
+                        </svg>
+                      </styled.svg>
+                    </LineChart>
+                  </div>
+                </EdgeCanvas>
+                <LineageCard
+                  addSpacer={false}
+                  isTarget={false}
+                  key="0"
+                  rows={
+                    Array [
+                      Object {
+                        "artifact": Object {
+                          "array": Array [
+                            1,
+                            1,
+                            "gs://my-bucket/mnist",
+                            Array [
+                              Array [
+                                "__ALL_META__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                ],
+                              ],
+                              Array [
+                                "create_time",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "2019-06-12T01:21:48.259263Z",
+                                ],
+                              ],
+                              Array [
+                                "description",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "A really great model",
+                                ],
+                              ],
+                              Array [
+                                "name",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "test model",
+                                ],
+                              ],
+                              Array [
+                                "version",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "v1",
+                                ],
+                              ],
+                            ],
+                            Array [
+                              Array [
+                                "__kf_run__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "1",
+                                ],
+                              ],
+                              Array [
+                                "__kf_workspace__",
+                                Array [
+                                  undefined,
+                                  undefined,
+                                  "workspace-1",
+                                ],
+                              ],
+                            ],
+                          ],
+                          "arrayIndexOffset_": -1,
+                          "convertedPrimitiveFields_": Object {},
+                          "messageId_": undefined,
+                          "pivot_": 1.7976931348623157e+308,
+                          "wrappers_": Object {
+                            "4": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__ALL_META__": Object {
+                                  "key": "__ALL_META__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "create_time": Object {
+                                  "key": "create_time",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "description": Object {
+                                  "key": "description",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "name": Object {
+                                  "key": "name",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "version": Object {
+                                  "key": "version",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                            "5": Object {
+                              "arrClean": true,
+                              "arr_": Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                              "map_": Object {
+                                "__kf_run__": Object {
+                                  "key": "__kf_run__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                                "__kf_workspace__": Object {
+                                  "key": "__kf_workspace__",
+                                  "value": Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                  "valueWrapper": Object {
+                                    "array": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "arrayIndexOffset_": -1,
+                                    "convertedPrimitiveFields_": Object {},
+                                    "messageId_": undefined,
+                                    "pivot_": 1.7976931348623157e+308,
+                                    "wrappers_": null,
+                                  },
+                                },
+                              },
+                              "valueCtor_": [Function],
+                            },
+                          },
+                        },
+                        "desc": "A really great model",
+                        "next": true,
+                        "prev": true,
+                        "title": "test model",
+                      },
+                    ]
+                  }
+                  setLineageViewTarget={[Function]}
+                  title="Artifact"
+                  type="artifact"
+                >
+                  <div
+                    className="cardContainer artifact"
+                  >
+                    <div
+                      className="cardTitle"
+                    >
+                      <h3>
+                        Artifact
+                      </h3>
+                    </div>
+                    <div
+                      className="cardBody"
+                    >
+                      <LineageCardRow
+                        artifact={
+                          Object {
+                            "array": Array [
+                              1,
+                              1,
+                              "gs://my-bucket/mnist",
+                              Array [
+                                Array [
+                                  "__ALL_META__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                  ],
+                                ],
+                                Array [
+                                  "create_time",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "2019-06-12T01:21:48.259263Z",
+                                  ],
+                                ],
+                                Array [
+                                  "description",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "A really great model",
+                                  ],
+                                ],
+                                Array [
+                                  "name",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "test model",
+                                  ],
+                                ],
+                                Array [
+                                  "version",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "v1",
+                                  ],
+                                ],
+                              ],
+                              Array [
+                                Array [
+                                  "__kf_run__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "1",
+                                  ],
+                                ],
+                                Array [
+                                  "__kf_workspace__",
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                    "workspace-1",
+                                  ],
+                                ],
+                              ],
+                            ],
+                            "arrayIndexOffset_": -1,
+                            "convertedPrimitiveFields_": Object {},
+                            "messageId_": undefined,
+                            "pivot_": 1.7976931348623157e+308,
+                            "wrappers_": Object {
+                              "4": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__ALL_META__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                  ],
+                                  Array [
+                                    "create_time",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                  ],
+                                  Array [
+                                    "description",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "name",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                  ],
+                                  Array [
+                                    "version",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__ALL_META__": Object {
+                                    "key": "__ALL_META__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "create_time": Object {
+                                    "key": "create_time",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "2019-06-12T01:21:48.259263Z",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "2019-06-12T01:21:48.259263Z",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "description": Object {
+                                    "key": "description",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "A really great model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "A really great model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "name": Object {
+                                    "key": "name",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "test model",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "test model",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "version": Object {
+                                    "key": "version",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "v1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "v1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                              "5": Object {
+                                "arrClean": true,
+                                "arr_": Array [
+                                  Array [
+                                    "__kf_run__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                  ],
+                                  Array [
+                                    "__kf_workspace__",
+                                    Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                  ],
+                                ],
+                                "map_": Object {
+                                  "__kf_run__": Object {
+                                    "key": "__kf_run__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                  "__kf_workspace__": Object {
+                                    "key": "__kf_workspace__",
+                                    "value": Array [
+                                      undefined,
+                                      undefined,
+                                      "workspace-1",
+                                    ],
+                                    "valueWrapper": Object {
+                                      "array": Array [
+                                        undefined,
+                                        undefined,
+                                        "workspace-1",
+                                      ],
+                                      "arrayIndexOffset_": -1,
+                                      "convertedPrimitiveFields_": Object {},
+                                      "messageId_": undefined,
+                                      "pivot_": 1.7976931348623157e+308,
+                                      "wrappers_": null,
+                                    },
+                                  },
+                                },
+                                "valueCtor_": [Function],
+                              },
+                            },
+                          }
+                        }
+                        description="A really great model"
+                        hideRadio={false}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        rightAffordance={true}
+                        setLineageViewTarget={[Function]}
+                        title="test model"
+                      >
+                        <div
+                          className="cardRow lastRow"
+                        >
+                          <div>
+                            <input
+                              className="form-radio"
+                              name=""
+                              onClick={[Function]}
+                              type="radio"
+                              value=""
+                            />
+                          </div>
+                          <footer>
+                            <p
+                              className="rowTitle"
+                            >
+                              test model
+                            </p>
+                            <p
+                              className="rowDesc"
+                            >
+                              A really great model
+                            </p>
+                          </footer>
+                          <div
+                            className="edgeLeft"
+                            key="edgeLeft"
+                          />
+                          <div
+                            className="edgeRight"
+                            key="edgeRight"
+                          />
+                        </div>
+                      </LineageCardRow>
+                    </div>
+                  </div>
+                </LineageCard>
+              </div>
+            </div>
+          </LineageCardColumn>
+        </div>
       </div>
-    </CircularProgress>
-  </WithStyles(CircularProgress)>
+    </LineageView>
+  </div>
 </ArtifactDetails>
 `;

--- a/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
@@ -8642,3 +8642,131 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
   </div>
 </ArtifactDetails>
 `;
+
+exports[`ArtifactDetails Shows error when returned Artifact is empty 1`] = `
+<ArtifactDetails
+  history={
+    Object {
+      "push": [MockFunction],
+    }
+  }
+  location={Object {}}
+  match={
+    Object {
+      "params": Object {
+        "artifactType": "kubeflow.org/alpha/model",
+        "id": "1",
+      },
+    }
+  }
+  toolbarProps={
+    Object {
+      "actions": Array [],
+      "breadcrumbs": Array [
+        Object {
+          "displayName": "Artifacts",
+          "href": "/artifacts",
+        },
+      ],
+      "pageTitle": "Model 1 details",
+    }
+  }
+  updateBanner={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "additionalInfo": undefined,
+            "message": "No kubeflow.org/alpha/model identified by id: 1",
+            "mode": "error",
+            "refresh": [Function],
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  updateDialog={[MockFunction]}
+  updateSnackbar={[MockFunction]}
+  updateToolbar={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "actions": Array [],
+            "breadcrumbs": Array [
+              Object {
+                "displayName": "Artifacts",
+                "href": "/artifacts",
+              },
+            ],
+            "pageTitle": "Model 1 details",
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+>
+  <WithStyles(CircularProgress)>
+    <CircularProgress
+      classes={
+        Object {
+          "circle": "MuiCircularProgress-circle-62",
+          "circleDisableShrink": "MuiCircularProgress-circleDisableShrink-65",
+          "circleIndeterminate": "MuiCircularProgress-circleIndeterminate-64",
+          "circleStatic": "MuiCircularProgress-circleStatic-63",
+          "colorPrimary": "MuiCircularProgress-colorPrimary-59",
+          "colorSecondary": "MuiCircularProgress-colorSecondary-60",
+          "indeterminate": "MuiCircularProgress-indeterminate-58",
+          "root": "MuiCircularProgress-root-56",
+          "static": "MuiCircularProgress-static-57",
+          "svg": "MuiCircularProgress-svg-61",
+        }
+      }
+      color="primary"
+      disableShrink={false}
+      size={40}
+      thickness={3.6}
+      value={0}
+      variant="indeterminate"
+    >
+      <div
+        className="MuiCircularProgress-root-56 MuiCircularProgress-colorPrimary-59 MuiCircularProgress-indeterminate-58"
+        role="progressbar"
+        style={
+          Object {
+            "height": 40,
+            "width": 40,
+          }
+        }
+      >
+        <svg
+          className="MuiCircularProgress-svg-61"
+          viewBox="22 22 44 44"
+        >
+          <circle
+            className="MuiCircularProgress-circle-62 MuiCircularProgress-circleIndeterminate-64"
+            cx={44}
+            cy={44}
+            fill="none"
+            r={20.2}
+            strokeWidth={3.6}
+            style={Object {}}
+          />
+        </svg>
+      </div>
+    </CircularProgress>
+  </WithStyles(CircularProgress)>
+</ArtifactDetails>
+`;

--- a/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
@@ -1193,7 +1193,9 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 Object {
                   "elements": Array [
                     Object {
-                      "artifact": Object {
+                      "next": true,
+                      "prev": true,
+                      "resource": Object {
                         "array": Array [
                           1,
                           1,
@@ -1478,10 +1480,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                           },
                         },
                       },
-                      "desc": "A really great model",
-                      "next": true,
-                      "prev": true,
-                      "title": "test model",
                     },
                   ],
                   "title": "Artifact",
@@ -1968,7 +1966,9 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   rows={
                     Array [
                       Object {
-                        "artifact": Object {
+                        "next": true,
+                        "prev": true,
+                        "resource": Object {
                           "array": Array [
                             1,
                             1,
@@ -2253,10 +2253,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             },
                           },
                         },
-                        "desc": "A really great model",
-                        "next": true,
-                        "prev": true,
-                        "title": "test model",
                       },
                     ]
                   }
@@ -2278,7 +2274,11 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       className="cardBody"
                     >
                       <LineageCardRow
-                        artifact={
+                        hideRadio={false}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        resource={
                           Object {
                             "array": Array [
                               1,
@@ -2565,14 +2565,8 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             },
                           }
                         }
-                        description="A really great model"
-                        hideRadio={false}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
                         rightAffordance={true}
                         setLineageViewTarget={[Function]}
-                        title="test model"
                       >
                         <div
                           className="cardRow lastRow"
@@ -2595,7 +2589,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             <p
                               className="rowDesc"
                             >
-                              A really great model
+                              workspace-1
                             </p>
                           </footer>
                           <div
@@ -2682,7 +2676,9 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 Object {
                   "elements": Array [
                     Object {
-                      "artifact": Object {
+                      "next": true,
+                      "prev": true,
+                      "resource": Object {
                         "array": Array [
                           1,
                           1,
@@ -2967,10 +2963,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                           },
                         },
                       },
-                      "desc": "A really great model",
-                      "next": true,
-                      "prev": true,
-                      "title": "test model",
                     },
                   ],
                   "title": "Artifact",
@@ -3456,7 +3448,9 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   rows={
                     Array [
                       Object {
-                        "artifact": Object {
+                        "next": true,
+                        "prev": true,
+                        "resource": Object {
                           "array": Array [
                             1,
                             1,
@@ -3741,10 +3735,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             },
                           },
                         },
-                        "desc": "A really great model",
-                        "next": true,
-                        "prev": true,
-                        "title": "test model",
                       },
                     ]
                   }
@@ -3765,7 +3755,11 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       className="cardBody"
                     >
                       <LineageCardRow
-                        artifact={
+                        hideRadio={true}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        resource={
                           Object {
                             "array": Array [
                               1,
@@ -4052,13 +4046,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             },
                           }
                         }
-                        description="A really great model"
-                        hideRadio={true}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
                         rightAffordance={true}
-                        title="test model"
                       >
                         <div
                           className="cardRow lastRow"
@@ -4075,7 +4063,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             <p
                               className="rowDesc"
                             >
-                              A really great model
+                              workspace-1
                             </p>
                           </footer>
                           <div
@@ -4162,7 +4150,9 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 Object {
                   "elements": Array [
                     Object {
-                      "artifact": Object {
+                      "next": true,
+                      "prev": true,
+                      "resource": Object {
                         "array": Array [
                           1,
                           1,
@@ -4447,10 +4437,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                           },
                         },
                       },
-                      "desc": "A really great model",
-                      "next": true,
-                      "prev": true,
-                      "title": "test model",
                     },
                   ],
                   "title": "Artifact",
@@ -4938,7 +4924,9 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   rows={
                     Array [
                       Object {
-                        "artifact": Object {
+                        "next": true,
+                        "prev": true,
+                        "resource": Object {
                           "array": Array [
                             1,
                             1,
@@ -5223,10 +5211,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             },
                           },
                         },
-                        "desc": "A really great model",
-                        "next": true,
-                        "prev": true,
-                        "title": "test model",
                       },
                     ]
                   }
@@ -5248,7 +5232,11 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       className="cardBody"
                     >
                       <LineageCardRow
-                        artifact={
+                        hideRadio={false}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        resource={
                           Object {
                             "array": Array [
                               1,
@@ -5535,14 +5523,8 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             },
                           }
                         }
-                        description="A really great model"
-                        hideRadio={false}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
                         rightAffordance={true}
                         setLineageViewTarget={[Function]}
-                        title="test model"
                       >
                         <div
                           className="cardRow lastRow"
@@ -5565,7 +5547,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                             <p
                               className="rowDesc"
                             >
-                              A really great model
+                              workspace-1
                             </p>
                           </footer>
                           <div
@@ -7586,7 +7568,9 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                 Object {
                   "elements": Array [
                     Object {
-                      "artifact": Object {
+                      "next": true,
+                      "prev": true,
+                      "resource": Object {
                         "array": Array [
                           1,
                           1,
@@ -7871,10 +7855,6 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                           },
                         },
                       },
-                      "desc": "A really great model",
-                      "next": true,
-                      "prev": true,
-                      "title": "test model",
                     },
                   ],
                   "title": "Artifact",
@@ -8361,7 +8341,9 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                   rows={
                     Array [
                       Object {
-                        "artifact": Object {
+                        "next": true,
+                        "prev": true,
+                        "resource": Object {
                           "array": Array [
                             1,
                             1,
@@ -8646,10 +8628,6 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             },
                           },
                         },
-                        "desc": "A really great model",
-                        "next": true,
-                        "prev": true,
-                        "title": "test model",
                       },
                     ]
                   }
@@ -8671,7 +8649,11 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                       className="cardBody"
                     >
                       <LineageCardRow
-                        artifact={
+                        hideRadio={false}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        resource={
                           Object {
                             "array": Array [
                               1,
@@ -8958,14 +8940,8 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             },
                           }
                         }
-                        description="A really great model"
-                        hideRadio={false}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
                         rightAffordance={true}
                         setLineageViewTarget={[Function]}
-                        title="test model"
                       >
                         <div
                           className="cardRow lastRow"
@@ -8988,7 +8964,7 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             <p
                               className="rowDesc"
                             >
-                              A really great model
+                              workspace-1
                             </p>
                           </footer>
                           <div
@@ -9075,7 +9051,9 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                 Object {
                   "elements": Array [
                     Object {
-                      "artifact": Object {
+                      "next": true,
+                      "prev": true,
+                      "resource": Object {
                         "array": Array [
                           1,
                           1,
@@ -9360,10 +9338,6 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                           },
                         },
                       },
-                      "desc": "A really great model",
-                      "next": true,
-                      "prev": true,
-                      "title": "test model",
                     },
                   ],
                   "title": "Artifact",
@@ -9849,7 +9823,9 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                   rows={
                     Array [
                       Object {
-                        "artifact": Object {
+                        "next": true,
+                        "prev": true,
+                        "resource": Object {
                           "array": Array [
                             1,
                             1,
@@ -10134,10 +10110,6 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             },
                           },
                         },
-                        "desc": "A really great model",
-                        "next": true,
-                        "prev": true,
-                        "title": "test model",
                       },
                     ]
                   }
@@ -10158,7 +10130,11 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                       className="cardBody"
                     >
                       <LineageCardRow
-                        artifact={
+                        hideRadio={true}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        resource={
                           Object {
                             "array": Array [
                               1,
@@ -10445,13 +10421,7 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             },
                           }
                         }
-                        description="A really great model"
-                        hideRadio={true}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
                         rightAffordance={true}
-                        title="test model"
                       >
                         <div
                           className="cardRow lastRow"
@@ -10468,7 +10438,7 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             <p
                               className="rowDesc"
                             >
-                              A really great model
+                              workspace-1
                             </p>
                           </footer>
                           <div
@@ -10555,7 +10525,9 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                 Object {
                   "elements": Array [
                     Object {
-                      "artifact": Object {
+                      "next": true,
+                      "prev": true,
+                      "resource": Object {
                         "array": Array [
                           1,
                           1,
@@ -10840,10 +10812,6 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                           },
                         },
                       },
-                      "desc": "A really great model",
-                      "next": true,
-                      "prev": true,
-                      "title": "test model",
                     },
                   ],
                   "title": "Artifact",
@@ -11331,7 +11299,9 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                   rows={
                     Array [
                       Object {
-                        "artifact": Object {
+                        "next": true,
+                        "prev": true,
+                        "resource": Object {
                           "array": Array [
                             1,
                             1,
@@ -11616,10 +11586,6 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             },
                           },
                         },
-                        "desc": "A really great model",
-                        "next": true,
-                        "prev": true,
-                        "title": "test model",
                       },
                     ]
                   }
@@ -11641,7 +11607,11 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                       className="cardBody"
                     >
                       <LineageCardRow
-                        artifact={
+                        hideRadio={false}
+                        isLastRow={true}
+                        key="0"
+                        leftAffordance={true}
+                        resource={
                           Object {
                             "array": Array [
                               1,
@@ -11928,14 +11898,8 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             },
                           }
                         }
-                        description="A really great model"
-                        hideRadio={false}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
                         rightAffordance={true}
                         setLineageViewTarget={[Function]}
-                        title="test model"
                       >
                         <div
                           className="cardRow lastRow"
@@ -11958,7 +11922,7 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                             <p
                               className="rowDesc"
                             >
-                              A really great model
+                              workspace-1
                             </p>
                           </footer>
                           <div

--- a/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
@@ -7144,32 +7144,32 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
               className="button active"
               classes={
                 Object {
-                  "colorInherit": "MuiButton-colorInherit-98",
-                  "contained": "MuiButton-contained-88",
-                  "containedPrimary": "MuiButton-containedPrimary-89",
-                  "containedSecondary": "MuiButton-containedSecondary-90",
-                  "disabled": "MuiButton-disabled-97",
-                  "extendedFab": "MuiButton-extendedFab-95",
-                  "fab": "MuiButton-fab-94",
-                  "flat": "MuiButton-flat-82",
-                  "flatPrimary": "MuiButton-flatPrimary-83",
-                  "flatSecondary": "MuiButton-flatSecondary-84",
-                  "focusVisible": "MuiButton-focusVisible-96",
-                  "fullWidth": "MuiButton-fullWidth-102",
-                  "label": "MuiButton-label-78",
-                  "mini": "MuiButton-mini-99",
-                  "outlined": "MuiButton-outlined-85",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-86",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-87",
-                  "raised": "MuiButton-raised-91",
-                  "raisedPrimary": "MuiButton-raisedPrimary-92",
-                  "raisedSecondary": "MuiButton-raisedSecondary-93",
-                  "root": "MuiButton-root-77",
-                  "sizeLarge": "MuiButton-sizeLarge-101",
-                  "sizeSmall": "MuiButton-sizeSmall-100",
-                  "text": "MuiButton-text-79",
-                  "textPrimary": "MuiButton-textPrimary-80",
-                  "textSecondary": "MuiButton-textSecondary-81",
+                  "colorInherit": "MuiButton-colorInherit-107",
+                  "contained": "MuiButton-contained-97",
+                  "containedPrimary": "MuiButton-containedPrimary-98",
+                  "containedSecondary": "MuiButton-containedSecondary-99",
+                  "disabled": "MuiButton-disabled-106",
+                  "extendedFab": "MuiButton-extendedFab-104",
+                  "fab": "MuiButton-fab-103",
+                  "flat": "MuiButton-flat-91",
+                  "flatPrimary": "MuiButton-flatPrimary-92",
+                  "flatSecondary": "MuiButton-flatSecondary-93",
+                  "focusVisible": "MuiButton-focusVisible-105",
+                  "fullWidth": "MuiButton-fullWidth-111",
+                  "label": "MuiButton-label-87",
+                  "mini": "MuiButton-mini-108",
+                  "outlined": "MuiButton-outlined-94",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-95",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-96",
+                  "raised": "MuiButton-raised-100",
+                  "raisedPrimary": "MuiButton-raisedPrimary-101",
+                  "raisedSecondary": "MuiButton-raisedSecondary-102",
+                  "root": "MuiButton-root-86",
+                  "sizeLarge": "MuiButton-sizeLarge-110",
+                  "sizeSmall": "MuiButton-sizeSmall-109",
+                  "text": "MuiButton-text-88",
+                  "textPrimary": "MuiButton-textPrimary-89",
+                  "textSecondary": "MuiButton-textSecondary-90",
                 }
               }
               color="default"
@@ -7184,22 +7184,22 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
               variant="text"
             >
               <WithStyles(ButtonBase)
-                className="MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button active"
+                className="MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button active"
                 component="button"
                 disabled={false}
                 focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-96"
+                focusVisibleClassName="MuiButton-focusVisible-105"
                 onClick={[Function]}
                 type="button"
               >
                 <ButtonBase
                   centerRipple={false}
-                  className="MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button active"
+                  className="MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button active"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-104",
-                      "focusVisible": "MuiButtonBase-focusVisible-105",
-                      "root": "MuiButtonBase-root-103",
+                      "disabled": "MuiButtonBase-disabled-113",
+                      "focusVisible": "MuiButtonBase-focusVisible-114",
+                      "root": "MuiButtonBase-root-112",
                     }
                   }
                   component="button"
@@ -7207,13 +7207,13 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                   disableTouchRipple={false}
                   disabled={false}
                   focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-96"
+                  focusVisibleClassName="MuiButton-focusVisible-105"
                   onClick={[Function]}
                   tabIndex="0"
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-103 MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button active"
+                    className="MuiButtonBase-root-112 MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button active"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -7231,7 +7231,7 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                     type="button"
                   >
                     <span
-                      className="MuiButton-label-78"
+                      className="MuiButton-label-87"
                     >
                       <span>
                         Overview
@@ -7249,25 +7249,25 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-110",
-                              "childLeaving": "MuiTouchRipple-childLeaving-111",
-                              "childPulsate": "MuiTouchRipple-childPulsate-112",
-                              "ripple": "MuiTouchRipple-ripple-107",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-109",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-108",
-                              "root": "MuiTouchRipple-root-106",
+                              "child": "MuiTouchRipple-child-119",
+                              "childLeaving": "MuiTouchRipple-childLeaving-120",
+                              "childPulsate": "MuiTouchRipple-childPulsate-121",
+                              "ripple": "MuiTouchRipple-ripple-116",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-118",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-117",
+                              "root": "MuiTouchRipple-root-115",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-106"
+                            className="MuiTouchRipple-root-115"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-106"
+                              className="MuiTouchRipple-root-115"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -7287,32 +7287,32 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
               className="button"
               classes={
                 Object {
-                  "colorInherit": "MuiButton-colorInherit-98",
-                  "contained": "MuiButton-contained-88",
-                  "containedPrimary": "MuiButton-containedPrimary-89",
-                  "containedSecondary": "MuiButton-containedSecondary-90",
-                  "disabled": "MuiButton-disabled-97",
-                  "extendedFab": "MuiButton-extendedFab-95",
-                  "fab": "MuiButton-fab-94",
-                  "flat": "MuiButton-flat-82",
-                  "flatPrimary": "MuiButton-flatPrimary-83",
-                  "flatSecondary": "MuiButton-flatSecondary-84",
-                  "focusVisible": "MuiButton-focusVisible-96",
-                  "fullWidth": "MuiButton-fullWidth-102",
-                  "label": "MuiButton-label-78",
-                  "mini": "MuiButton-mini-99",
-                  "outlined": "MuiButton-outlined-85",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-86",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-87",
-                  "raised": "MuiButton-raised-91",
-                  "raisedPrimary": "MuiButton-raisedPrimary-92",
-                  "raisedSecondary": "MuiButton-raisedSecondary-93",
-                  "root": "MuiButton-root-77",
-                  "sizeLarge": "MuiButton-sizeLarge-101",
-                  "sizeSmall": "MuiButton-sizeSmall-100",
-                  "text": "MuiButton-text-79",
-                  "textPrimary": "MuiButton-textPrimary-80",
-                  "textSecondary": "MuiButton-textSecondary-81",
+                  "colorInherit": "MuiButton-colorInherit-107",
+                  "contained": "MuiButton-contained-97",
+                  "containedPrimary": "MuiButton-containedPrimary-98",
+                  "containedSecondary": "MuiButton-containedSecondary-99",
+                  "disabled": "MuiButton-disabled-106",
+                  "extendedFab": "MuiButton-extendedFab-104",
+                  "fab": "MuiButton-fab-103",
+                  "flat": "MuiButton-flat-91",
+                  "flatPrimary": "MuiButton-flatPrimary-92",
+                  "flatSecondary": "MuiButton-flatSecondary-93",
+                  "focusVisible": "MuiButton-focusVisible-105",
+                  "fullWidth": "MuiButton-fullWidth-111",
+                  "label": "MuiButton-label-87",
+                  "mini": "MuiButton-mini-108",
+                  "outlined": "MuiButton-outlined-94",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-95",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-96",
+                  "raised": "MuiButton-raised-100",
+                  "raisedPrimary": "MuiButton-raisedPrimary-101",
+                  "raisedSecondary": "MuiButton-raisedSecondary-102",
+                  "root": "MuiButton-root-86",
+                  "sizeLarge": "MuiButton-sizeLarge-110",
+                  "sizeSmall": "MuiButton-sizeSmall-109",
+                  "text": "MuiButton-text-88",
+                  "textPrimary": "MuiButton-textPrimary-89",
+                  "textSecondary": "MuiButton-textSecondary-90",
                 }
               }
               color="default"
@@ -7327,22 +7327,22 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
               variant="text"
             >
               <WithStyles(ButtonBase)
-                className="MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button"
+                className="MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button"
                 component="button"
                 disabled={false}
                 focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-96"
+                focusVisibleClassName="MuiButton-focusVisible-105"
                 onClick={[Function]}
                 type="button"
               >
                 <ButtonBase
                   centerRipple={false}
-                  className="MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button"
+                  className="MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-104",
-                      "focusVisible": "MuiButtonBase-focusVisible-105",
-                      "root": "MuiButtonBase-root-103",
+                      "disabled": "MuiButtonBase-disabled-113",
+                      "focusVisible": "MuiButtonBase-focusVisible-114",
+                      "root": "MuiButtonBase-root-112",
                     }
                   }
                   component="button"
@@ -7350,13 +7350,13 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                   disableTouchRipple={false}
                   disabled={false}
                   focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-96"
+                  focusVisibleClassName="MuiButton-focusVisible-105"
                   onClick={[Function]}
                   tabIndex="0"
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-103 MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button"
+                    className="MuiButtonBase-root-112 MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -7374,7 +7374,7 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                     type="button"
                   >
                     <span
-                      className="MuiButton-label-78"
+                      className="MuiButton-label-87"
                     >
                       <span>
                         Lineage Explorer
@@ -7392,25 +7392,25 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-110",
-                              "childLeaving": "MuiTouchRipple-childLeaving-111",
-                              "childPulsate": "MuiTouchRipple-childPulsate-112",
-                              "ripple": "MuiTouchRipple-ripple-107",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-109",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-108",
-                              "root": "MuiTouchRipple-root-106",
+                              "child": "MuiTouchRipple-child-119",
+                              "childLeaving": "MuiTouchRipple-childLeaving-120",
+                              "childPulsate": "MuiTouchRipple-childPulsate-121",
+                              "ripple": "MuiTouchRipple-ripple-116",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-118",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-117",
+                              "root": "MuiTouchRipple-root-115",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-106"
+                            className="MuiTouchRipple-root-115"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-106"
+                              className="MuiTouchRipple-root-115"
                             />
                           </TransitionGroup>
                         </TouchRipple>

--- a/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
@@ -111,32 +111,32 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
               className="button"
               classes={
                 Object {
-                  "colorInherit": "MuiButton-colorInherit-153",
-                  "contained": "MuiButton-contained-143",
-                  "containedPrimary": "MuiButton-containedPrimary-144",
-                  "containedSecondary": "MuiButton-containedSecondary-145",
-                  "disabled": "MuiButton-disabled-152",
-                  "extendedFab": "MuiButton-extendedFab-150",
-                  "fab": "MuiButton-fab-149",
-                  "flat": "MuiButton-flat-137",
-                  "flatPrimary": "MuiButton-flatPrimary-138",
-                  "flatSecondary": "MuiButton-flatSecondary-139",
-                  "focusVisible": "MuiButton-focusVisible-151",
-                  "fullWidth": "MuiButton-fullWidth-157",
-                  "label": "MuiButton-label-133",
-                  "mini": "MuiButton-mini-154",
-                  "outlined": "MuiButton-outlined-140",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-141",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-142",
-                  "raised": "MuiButton-raised-146",
-                  "raisedPrimary": "MuiButton-raisedPrimary-147",
-                  "raisedSecondary": "MuiButton-raisedSecondary-148",
-                  "root": "MuiButton-root-132",
-                  "sizeLarge": "MuiButton-sizeLarge-156",
-                  "sizeSmall": "MuiButton-sizeSmall-155",
-                  "text": "MuiButton-text-134",
-                  "textPrimary": "MuiButton-textPrimary-135",
-                  "textSecondary": "MuiButton-textSecondary-136",
+                  "colorInherit": "MuiButton-colorInherit-144",
+                  "contained": "MuiButton-contained-134",
+                  "containedPrimary": "MuiButton-containedPrimary-135",
+                  "containedSecondary": "MuiButton-containedSecondary-136",
+                  "disabled": "MuiButton-disabled-143",
+                  "extendedFab": "MuiButton-extendedFab-141",
+                  "fab": "MuiButton-fab-140",
+                  "flat": "MuiButton-flat-128",
+                  "flatPrimary": "MuiButton-flatPrimary-129",
+                  "flatSecondary": "MuiButton-flatSecondary-130",
+                  "focusVisible": "MuiButton-focusVisible-142",
+                  "fullWidth": "MuiButton-fullWidth-148",
+                  "label": "MuiButton-label-124",
+                  "mini": "MuiButton-mini-145",
+                  "outlined": "MuiButton-outlined-131",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-132",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-133",
+                  "raised": "MuiButton-raised-137",
+                  "raisedPrimary": "MuiButton-raisedPrimary-138",
+                  "raisedSecondary": "MuiButton-raisedSecondary-139",
+                  "root": "MuiButton-root-123",
+                  "sizeLarge": "MuiButton-sizeLarge-147",
+                  "sizeSmall": "MuiButton-sizeSmall-146",
+                  "text": "MuiButton-text-125",
+                  "textPrimary": "MuiButton-textPrimary-126",
+                  "textSecondary": "MuiButton-textSecondary-127",
                 }
               }
               color="default"
@@ -151,22 +151,22 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
               variant="text"
             >
               <WithStyles(ButtonBase)
-                className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button"
+                className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button"
                 component="button"
                 disabled={false}
                 focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-151"
+                focusVisibleClassName="MuiButton-focusVisible-142"
                 onClick={[Function]}
                 type="button"
               >
                 <ButtonBase
                   centerRipple={false}
-                  className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button"
+                  className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-159",
-                      "focusVisible": "MuiButtonBase-focusVisible-160",
-                      "root": "MuiButtonBase-root-158",
+                      "disabled": "MuiButtonBase-disabled-150",
+                      "focusVisible": "MuiButtonBase-focusVisible-151",
+                      "root": "MuiButtonBase-root-149",
                     }
                   }
                   component="button"
@@ -174,13 +174,13 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   disableTouchRipple={false}
                   disabled={false}
                   focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-151"
+                  focusVisibleClassName="MuiButton-focusVisible-142"
                   onClick={[Function]}
                   tabIndex="0"
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-158 MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button"
+                    className="MuiButtonBase-root-149 MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -198,7 +198,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                     type="button"
                   >
                     <span
-                      className="MuiButton-label-133"
+                      className="MuiButton-label-124"
                     >
                       <span>
                         Overview
@@ -216,25 +216,25 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-174",
-                              "childLeaving": "MuiTouchRipple-childLeaving-175",
-                              "childPulsate": "MuiTouchRipple-childPulsate-176",
-                              "ripple": "MuiTouchRipple-ripple-171",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-173",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-172",
-                              "root": "MuiTouchRipple-root-170",
+                              "child": "MuiTouchRipple-child-165",
+                              "childLeaving": "MuiTouchRipple-childLeaving-166",
+                              "childPulsate": "MuiTouchRipple-childPulsate-167",
+                              "ripple": "MuiTouchRipple-ripple-162",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-164",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-163",
+                              "root": "MuiTouchRipple-root-161",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-170"
+                            className="MuiTouchRipple-root-161"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-170"
+                              className="MuiTouchRipple-root-161"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -254,32 +254,32 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
               className="button active"
               classes={
                 Object {
-                  "colorInherit": "MuiButton-colorInherit-153",
-                  "contained": "MuiButton-contained-143",
-                  "containedPrimary": "MuiButton-containedPrimary-144",
-                  "containedSecondary": "MuiButton-containedSecondary-145",
-                  "disabled": "MuiButton-disabled-152",
-                  "extendedFab": "MuiButton-extendedFab-150",
-                  "fab": "MuiButton-fab-149",
-                  "flat": "MuiButton-flat-137",
-                  "flatPrimary": "MuiButton-flatPrimary-138",
-                  "flatSecondary": "MuiButton-flatSecondary-139",
-                  "focusVisible": "MuiButton-focusVisible-151",
-                  "fullWidth": "MuiButton-fullWidth-157",
-                  "label": "MuiButton-label-133",
-                  "mini": "MuiButton-mini-154",
-                  "outlined": "MuiButton-outlined-140",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-141",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-142",
-                  "raised": "MuiButton-raised-146",
-                  "raisedPrimary": "MuiButton-raisedPrimary-147",
-                  "raisedSecondary": "MuiButton-raisedSecondary-148",
-                  "root": "MuiButton-root-132",
-                  "sizeLarge": "MuiButton-sizeLarge-156",
-                  "sizeSmall": "MuiButton-sizeSmall-155",
-                  "text": "MuiButton-text-134",
-                  "textPrimary": "MuiButton-textPrimary-135",
-                  "textSecondary": "MuiButton-textSecondary-136",
+                  "colorInherit": "MuiButton-colorInherit-144",
+                  "contained": "MuiButton-contained-134",
+                  "containedPrimary": "MuiButton-containedPrimary-135",
+                  "containedSecondary": "MuiButton-containedSecondary-136",
+                  "disabled": "MuiButton-disabled-143",
+                  "extendedFab": "MuiButton-extendedFab-141",
+                  "fab": "MuiButton-fab-140",
+                  "flat": "MuiButton-flat-128",
+                  "flatPrimary": "MuiButton-flatPrimary-129",
+                  "flatSecondary": "MuiButton-flatSecondary-130",
+                  "focusVisible": "MuiButton-focusVisible-142",
+                  "fullWidth": "MuiButton-fullWidth-148",
+                  "label": "MuiButton-label-124",
+                  "mini": "MuiButton-mini-145",
+                  "outlined": "MuiButton-outlined-131",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-132",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-133",
+                  "raised": "MuiButton-raised-137",
+                  "raisedPrimary": "MuiButton-raisedPrimary-138",
+                  "raisedSecondary": "MuiButton-raisedSecondary-139",
+                  "root": "MuiButton-root-123",
+                  "sizeLarge": "MuiButton-sizeLarge-147",
+                  "sizeSmall": "MuiButton-sizeSmall-146",
+                  "text": "MuiButton-text-125",
+                  "textPrimary": "MuiButton-textPrimary-126",
+                  "textSecondary": "MuiButton-textSecondary-127",
                 }
               }
               color="default"
@@ -294,22 +294,22 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
               variant="text"
             >
               <WithStyles(ButtonBase)
-                className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button active"
+                className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button active"
                 component="button"
                 disabled={false}
                 focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-151"
+                focusVisibleClassName="MuiButton-focusVisible-142"
                 onClick={[Function]}
                 type="button"
               >
                 <ButtonBase
                   centerRipple={false}
-                  className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button active"
+                  className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button active"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-159",
-                      "focusVisible": "MuiButtonBase-focusVisible-160",
-                      "root": "MuiButtonBase-root-158",
+                      "disabled": "MuiButtonBase-disabled-150",
+                      "focusVisible": "MuiButtonBase-focusVisible-151",
+                      "root": "MuiButtonBase-root-149",
                     }
                   }
                   component="button"
@@ -317,13 +317,13 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   disableTouchRipple={false}
                   disabled={false}
                   focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-151"
+                  focusVisibleClassName="MuiButton-focusVisible-142"
                   onClick={[Function]}
                   tabIndex="0"
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-158 MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 button active"
+                    className="MuiButtonBase-root-149 MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 button active"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -341,7 +341,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                     type="button"
                   >
                     <span
-                      className="MuiButton-label-133"
+                      className="MuiButton-label-124"
                     >
                       <span>
                         Lineage Explorer
@@ -359,25 +359,25 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-174",
-                              "childLeaving": "MuiTouchRipple-childLeaving-175",
-                              "childPulsate": "MuiTouchRipple-childPulsate-176",
-                              "ripple": "MuiTouchRipple-ripple-171",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-173",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-172",
-                              "root": "MuiTouchRipple-root-170",
+                              "child": "MuiTouchRipple-child-165",
+                              "childLeaving": "MuiTouchRipple-childLeaving-166",
+                              "childPulsate": "MuiTouchRipple-childPulsate-167",
+                              "ripple": "MuiTouchRipple-ripple-162",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-164",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-163",
+                              "root": "MuiTouchRipple-root-161",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-170"
+                            className="MuiTouchRipple-root-161"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-170"
+                              className="MuiTouchRipple-root-161"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -998,32 +998,32 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   className="actionButton"
                   classes={
                     Object {
-                      "colorInherit": "MuiButton-colorInherit-153",
-                      "contained": "MuiButton-contained-143",
-                      "containedPrimary": "MuiButton-containedPrimary-144",
-                      "containedSecondary": "MuiButton-containedSecondary-145",
-                      "disabled": "MuiButton-disabled-152",
-                      "extendedFab": "MuiButton-extendedFab-150",
-                      "fab": "MuiButton-fab-149",
-                      "flat": "MuiButton-flat-137",
-                      "flatPrimary": "MuiButton-flatPrimary-138",
-                      "flatSecondary": "MuiButton-flatSecondary-139",
-                      "focusVisible": "MuiButton-focusVisible-151",
-                      "fullWidth": "MuiButton-fullWidth-157",
-                      "label": "MuiButton-label-133",
-                      "mini": "MuiButton-mini-154",
-                      "outlined": "MuiButton-outlined-140",
-                      "outlinedPrimary": "MuiButton-outlinedPrimary-141",
-                      "outlinedSecondary": "MuiButton-outlinedSecondary-142",
-                      "raised": "MuiButton-raised-146",
-                      "raisedPrimary": "MuiButton-raisedPrimary-147",
-                      "raisedSecondary": "MuiButton-raisedSecondary-148",
-                      "root": "MuiButton-root-132",
-                      "sizeLarge": "MuiButton-sizeLarge-156",
-                      "sizeSmall": "MuiButton-sizeSmall-155",
-                      "text": "MuiButton-text-134",
-                      "textPrimary": "MuiButton-textPrimary-135",
-                      "textSecondary": "MuiButton-textSecondary-136",
+                      "colorInherit": "MuiButton-colorInherit-144",
+                      "contained": "MuiButton-contained-134",
+                      "containedPrimary": "MuiButton-containedPrimary-135",
+                      "containedSecondary": "MuiButton-containedSecondary-136",
+                      "disabled": "MuiButton-disabled-143",
+                      "extendedFab": "MuiButton-extendedFab-141",
+                      "fab": "MuiButton-fab-140",
+                      "flat": "MuiButton-flat-128",
+                      "flatPrimary": "MuiButton-flatPrimary-129",
+                      "flatSecondary": "MuiButton-flatSecondary-130",
+                      "focusVisible": "MuiButton-focusVisible-142",
+                      "fullWidth": "MuiButton-fullWidth-148",
+                      "label": "MuiButton-label-124",
+                      "mini": "MuiButton-mini-145",
+                      "outlined": "MuiButton-outlined-131",
+                      "outlinedPrimary": "MuiButton-outlinedPrimary-132",
+                      "outlinedSecondary": "MuiButton-outlinedSecondary-133",
+                      "raised": "MuiButton-raised-137",
+                      "raisedPrimary": "MuiButton-raisedPrimary-138",
+                      "raisedSecondary": "MuiButton-raisedSecondary-139",
+                      "root": "MuiButton-root-123",
+                      "sizeLarge": "MuiButton-sizeLarge-147",
+                      "sizeSmall": "MuiButton-sizeSmall-146",
+                      "text": "MuiButton-text-125",
+                      "textPrimary": "MuiButton-textPrimary-126",
+                      "textSecondary": "MuiButton-textSecondary-127",
                     }
                   }
                   color="default"
@@ -1038,22 +1038,22 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                   variant="text"
                 >
                   <WithStyles(ButtonBase)
-                    className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 actionButton"
+                    className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 actionButton"
                     component="button"
                     disabled={false}
                     focusRipple={true}
-                    focusVisibleClassName="MuiButton-focusVisible-151"
+                    focusVisibleClassName="MuiButton-focusVisible-142"
                     onClick={[Function]}
                     type="button"
                   >
                     <ButtonBase
                       centerRipple={false}
-                      className="MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 actionButton"
+                      className="MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 actionButton"
                       classes={
                         Object {
-                          "disabled": "MuiButtonBase-disabled-159",
-                          "focusVisible": "MuiButtonBase-focusVisible-160",
-                          "root": "MuiButtonBase-root-158",
+                          "disabled": "MuiButtonBase-disabled-150",
+                          "focusVisible": "MuiButtonBase-focusVisible-151",
+                          "root": "MuiButtonBase-root-149",
                         }
                       }
                       component="button"
@@ -1061,13 +1061,13 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       disableTouchRipple={false}
                       disabled={false}
                       focusRipple={true}
-                      focusVisibleClassName="MuiButton-focusVisible-151"
+                      focusVisibleClassName="MuiButton-focusVisible-142"
                       onClick={[Function]}
                       tabIndex="0"
                       type="button"
                     >
                       <button
-                        className="MuiButtonBase-root-158 MuiButton-root-132 MuiButton-text-134 MuiButton-flat-137 actionButton"
+                        className="MuiButtonBase-root-149 MuiButton-root-123 MuiButton-text-125 MuiButton-flat-128 actionButton"
                         disabled={false}
                         onBlur={[Function]}
                         onClick={[Function]}
@@ -1085,7 +1085,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                         type="button"
                       >
                         <span
-                          className="MuiButton-label-133"
+                          className="MuiButton-label-124"
                         >
                           <pure(ReplayIcon)>
                             <ReplayIcon>
@@ -1093,15 +1093,15 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                                 <SvgIcon
                                   classes={
                                     Object {
-                                      "colorAction": "MuiSvgIcon-colorAction-164",
-                                      "colorDisabled": "MuiSvgIcon-colorDisabled-166",
-                                      "colorError": "MuiSvgIcon-colorError-165",
-                                      "colorPrimary": "MuiSvgIcon-colorPrimary-162",
-                                      "colorSecondary": "MuiSvgIcon-colorSecondary-163",
-                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-167",
-                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-169",
-                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-168",
-                                      "root": "MuiSvgIcon-root-161",
+                                      "colorAction": "MuiSvgIcon-colorAction-155",
+                                      "colorDisabled": "MuiSvgIcon-colorDisabled-157",
+                                      "colorError": "MuiSvgIcon-colorError-156",
+                                      "colorPrimary": "MuiSvgIcon-colorPrimary-153",
+                                      "colorSecondary": "MuiSvgIcon-colorSecondary-154",
+                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-158",
+                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-160",
+                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-159",
+                                      "root": "MuiSvgIcon-root-152",
                                     }
                                   }
                                   color="inherit"
@@ -1111,7 +1111,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    className="MuiSvgIcon-root-161"
+                                    className="MuiSvgIcon-root-152"
                                     focusable="false"
                                     role="presentation"
                                     viewBox="0 0 24 24"
@@ -1142,25 +1142,25 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                               center={false}
                               classes={
                                 Object {
-                                  "child": "MuiTouchRipple-child-174",
-                                  "childLeaving": "MuiTouchRipple-childLeaving-175",
-                                  "childPulsate": "MuiTouchRipple-childPulsate-176",
-                                  "ripple": "MuiTouchRipple-ripple-171",
-                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-173",
-                                  "rippleVisible": "MuiTouchRipple-rippleVisible-172",
-                                  "root": "MuiTouchRipple-root-170",
+                                  "child": "MuiTouchRipple-child-165",
+                                  "childLeaving": "MuiTouchRipple-childLeaving-166",
+                                  "childPulsate": "MuiTouchRipple-childPulsate-167",
+                                  "ripple": "MuiTouchRipple-ripple-162",
+                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-164",
+                                  "rippleVisible": "MuiTouchRipple-rippleVisible-163",
+                                  "root": "MuiTouchRipple-root-161",
                                 }
                               }
                             >
                               <TransitionGroup
                                 childFactory={[Function]}
-                                className="MuiTouchRipple-root-170"
+                                className="MuiTouchRipple-root-161"
                                 component="span"
                                 enter={true}
                                 exit={true}
                               >
                                 <span
-                                  className="MuiTouchRipple-root-170"
+                                  className="MuiTouchRipple-root-161"
                                 />
                               </TransitionGroup>
                             </TouchRipple>
@@ -5682,32 +5682,32 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
               className="button active"
               classes={
                 Object {
-                  "colorInherit": "MuiButton-colorInherit-107",
-                  "contained": "MuiButton-contained-97",
-                  "containedPrimary": "MuiButton-containedPrimary-98",
-                  "containedSecondary": "MuiButton-containedSecondary-99",
-                  "disabled": "MuiButton-disabled-106",
-                  "extendedFab": "MuiButton-extendedFab-104",
-                  "fab": "MuiButton-fab-103",
-                  "flat": "MuiButton-flat-91",
-                  "flatPrimary": "MuiButton-flatPrimary-92",
-                  "flatSecondary": "MuiButton-flatSecondary-93",
-                  "focusVisible": "MuiButton-focusVisible-105",
-                  "fullWidth": "MuiButton-fullWidth-111",
-                  "label": "MuiButton-label-87",
-                  "mini": "MuiButton-mini-108",
-                  "outlined": "MuiButton-outlined-94",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-95",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-96",
-                  "raised": "MuiButton-raised-100",
-                  "raisedPrimary": "MuiButton-raisedPrimary-101",
-                  "raisedSecondary": "MuiButton-raisedSecondary-102",
-                  "root": "MuiButton-root-86",
-                  "sizeLarge": "MuiButton-sizeLarge-110",
-                  "sizeSmall": "MuiButton-sizeSmall-109",
-                  "text": "MuiButton-text-88",
-                  "textPrimary": "MuiButton-textPrimary-89",
-                  "textSecondary": "MuiButton-textSecondary-90",
+                  "colorInherit": "MuiButton-colorInherit-98",
+                  "contained": "MuiButton-contained-88",
+                  "containedPrimary": "MuiButton-containedPrimary-89",
+                  "containedSecondary": "MuiButton-containedSecondary-90",
+                  "disabled": "MuiButton-disabled-97",
+                  "extendedFab": "MuiButton-extendedFab-95",
+                  "fab": "MuiButton-fab-94",
+                  "flat": "MuiButton-flat-82",
+                  "flatPrimary": "MuiButton-flatPrimary-83",
+                  "flatSecondary": "MuiButton-flatSecondary-84",
+                  "focusVisible": "MuiButton-focusVisible-96",
+                  "fullWidth": "MuiButton-fullWidth-102",
+                  "label": "MuiButton-label-78",
+                  "mini": "MuiButton-mini-99",
+                  "outlined": "MuiButton-outlined-85",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-86",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-87",
+                  "raised": "MuiButton-raised-91",
+                  "raisedPrimary": "MuiButton-raisedPrimary-92",
+                  "raisedSecondary": "MuiButton-raisedSecondary-93",
+                  "root": "MuiButton-root-77",
+                  "sizeLarge": "MuiButton-sizeLarge-101",
+                  "sizeSmall": "MuiButton-sizeSmall-100",
+                  "text": "MuiButton-text-79",
+                  "textPrimary": "MuiButton-textPrimary-80",
+                  "textSecondary": "MuiButton-textSecondary-81",
                 }
               }
               color="default"
@@ -5722,22 +5722,22 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
               variant="text"
             >
               <WithStyles(ButtonBase)
-                className="MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button active"
+                className="MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button active"
                 component="button"
                 disabled={false}
                 focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-105"
+                focusVisibleClassName="MuiButton-focusVisible-96"
                 onClick={[Function]}
                 type="button"
               >
                 <ButtonBase
                   centerRipple={false}
-                  className="MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button active"
+                  className="MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button active"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-113",
-                      "focusVisible": "MuiButtonBase-focusVisible-114",
-                      "root": "MuiButtonBase-root-112",
+                      "disabled": "MuiButtonBase-disabled-104",
+                      "focusVisible": "MuiButtonBase-focusVisible-105",
+                      "root": "MuiButtonBase-root-103",
                     }
                   }
                   component="button"
@@ -5745,13 +5745,13 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                   disableTouchRipple={false}
                   disabled={false}
                   focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-105"
+                  focusVisibleClassName="MuiButton-focusVisible-96"
                   onClick={[Function]}
                   tabIndex="0"
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-112 MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button active"
+                    className="MuiButtonBase-root-103 MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button active"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5769,7 +5769,7 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                     type="button"
                   >
                     <span
-                      className="MuiButton-label-87"
+                      className="MuiButton-label-78"
                     >
                       <span>
                         Overview
@@ -5787,25 +5787,25 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-119",
-                              "childLeaving": "MuiTouchRipple-childLeaving-120",
-                              "childPulsate": "MuiTouchRipple-childPulsate-121",
-                              "ripple": "MuiTouchRipple-ripple-116",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-118",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-117",
-                              "root": "MuiTouchRipple-root-115",
+                              "child": "MuiTouchRipple-child-110",
+                              "childLeaving": "MuiTouchRipple-childLeaving-111",
+                              "childPulsate": "MuiTouchRipple-childPulsate-112",
+                              "ripple": "MuiTouchRipple-ripple-107",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-109",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-108",
+                              "root": "MuiTouchRipple-root-106",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-115"
+                            className="MuiTouchRipple-root-106"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-115"
+                              className="MuiTouchRipple-root-106"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -5825,32 +5825,32 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
               className="button"
               classes={
                 Object {
-                  "colorInherit": "MuiButton-colorInherit-107",
-                  "contained": "MuiButton-contained-97",
-                  "containedPrimary": "MuiButton-containedPrimary-98",
-                  "containedSecondary": "MuiButton-containedSecondary-99",
-                  "disabled": "MuiButton-disabled-106",
-                  "extendedFab": "MuiButton-extendedFab-104",
-                  "fab": "MuiButton-fab-103",
-                  "flat": "MuiButton-flat-91",
-                  "flatPrimary": "MuiButton-flatPrimary-92",
-                  "flatSecondary": "MuiButton-flatSecondary-93",
-                  "focusVisible": "MuiButton-focusVisible-105",
-                  "fullWidth": "MuiButton-fullWidth-111",
-                  "label": "MuiButton-label-87",
-                  "mini": "MuiButton-mini-108",
-                  "outlined": "MuiButton-outlined-94",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-95",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-96",
-                  "raised": "MuiButton-raised-100",
-                  "raisedPrimary": "MuiButton-raisedPrimary-101",
-                  "raisedSecondary": "MuiButton-raisedSecondary-102",
-                  "root": "MuiButton-root-86",
-                  "sizeLarge": "MuiButton-sizeLarge-110",
-                  "sizeSmall": "MuiButton-sizeSmall-109",
-                  "text": "MuiButton-text-88",
-                  "textPrimary": "MuiButton-textPrimary-89",
-                  "textSecondary": "MuiButton-textSecondary-90",
+                  "colorInherit": "MuiButton-colorInherit-98",
+                  "contained": "MuiButton-contained-88",
+                  "containedPrimary": "MuiButton-containedPrimary-89",
+                  "containedSecondary": "MuiButton-containedSecondary-90",
+                  "disabled": "MuiButton-disabled-97",
+                  "extendedFab": "MuiButton-extendedFab-95",
+                  "fab": "MuiButton-fab-94",
+                  "flat": "MuiButton-flat-82",
+                  "flatPrimary": "MuiButton-flatPrimary-83",
+                  "flatSecondary": "MuiButton-flatSecondary-84",
+                  "focusVisible": "MuiButton-focusVisible-96",
+                  "fullWidth": "MuiButton-fullWidth-102",
+                  "label": "MuiButton-label-78",
+                  "mini": "MuiButton-mini-99",
+                  "outlined": "MuiButton-outlined-85",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-86",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-87",
+                  "raised": "MuiButton-raised-91",
+                  "raisedPrimary": "MuiButton-raisedPrimary-92",
+                  "raisedSecondary": "MuiButton-raisedSecondary-93",
+                  "root": "MuiButton-root-77",
+                  "sizeLarge": "MuiButton-sizeLarge-101",
+                  "sizeSmall": "MuiButton-sizeSmall-100",
+                  "text": "MuiButton-text-79",
+                  "textPrimary": "MuiButton-textPrimary-80",
+                  "textSecondary": "MuiButton-textSecondary-81",
                 }
               }
               color="default"
@@ -5865,22 +5865,22 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
               variant="text"
             >
               <WithStyles(ButtonBase)
-                className="MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button"
+                className="MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button"
                 component="button"
                 disabled={false}
                 focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-105"
+                focusVisibleClassName="MuiButton-focusVisible-96"
                 onClick={[Function]}
                 type="button"
               >
                 <ButtonBase
                   centerRipple={false}
-                  className="MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button"
+                  className="MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-113",
-                      "focusVisible": "MuiButtonBase-focusVisible-114",
-                      "root": "MuiButtonBase-root-112",
+                      "disabled": "MuiButtonBase-disabled-104",
+                      "focusVisible": "MuiButtonBase-focusVisible-105",
+                      "root": "MuiButtonBase-root-103",
                     }
                   }
                   component="button"
@@ -5888,13 +5888,13 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                   disableTouchRipple={false}
                   disabled={false}
                   focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-105"
+                  focusVisibleClassName="MuiButton-focusVisible-96"
                   onClick={[Function]}
                   tabIndex="0"
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-112 MuiButton-root-86 MuiButton-text-88 MuiButton-flat-91 button"
+                    className="MuiButtonBase-root-103 MuiButton-root-77 MuiButton-text-79 MuiButton-flat-82 button"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5912,7 +5912,7 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                     type="button"
                   >
                     <span
-                      className="MuiButton-label-87"
+                      className="MuiButton-label-78"
                     >
                       <span>
                         Lineage Explorer
@@ -5930,25 +5930,25 @@ exports[`ArtifactDetails Renders the Overview tab for an artifact 1`] = `
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-119",
-                              "childLeaving": "MuiTouchRipple-childLeaving-120",
-                              "childPulsate": "MuiTouchRipple-childPulsate-121",
-                              "ripple": "MuiTouchRipple-ripple-116",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-118",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-117",
-                              "root": "MuiTouchRipple-root-115",
+                              "child": "MuiTouchRipple-child-110",
+                              "childLeaving": "MuiTouchRipple-childLeaving-111",
+                              "childPulsate": "MuiTouchRipple-childPulsate-112",
+                              "ripple": "MuiTouchRipple-ripple-107",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-109",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-108",
+                              "root": "MuiTouchRipple-root-106",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-115"
+                            className="MuiTouchRipple-root-106"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-115"
+                              className="MuiTouchRipple-root-106"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -6450,7 +6450,7 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
     >
       <MD2Tabs
         onSwitch={[Function]}
-        selectedTab={1}
+        selectedTab={0}
         tabs={
           Array [
             "Overview",
@@ -6478,151 +6478,8 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
             />
           </_default>
           <WithStyles(Button)
-            className="button"
-            key="0"
-            onClick={[Function]}
-          >
-            <Button
-              className="button"
-              classes={
-                Object {
-                  "colorInherit": "MuiButton-colorInherit-32",
-                  "contained": "MuiButton-contained-22",
-                  "containedPrimary": "MuiButton-containedPrimary-23",
-                  "containedSecondary": "MuiButton-containedSecondary-24",
-                  "disabled": "MuiButton-disabled-31",
-                  "extendedFab": "MuiButton-extendedFab-29",
-                  "fab": "MuiButton-fab-28",
-                  "flat": "MuiButton-flat-16",
-                  "flatPrimary": "MuiButton-flatPrimary-17",
-                  "flatSecondary": "MuiButton-flatSecondary-18",
-                  "focusVisible": "MuiButton-focusVisible-30",
-                  "fullWidth": "MuiButton-fullWidth-36",
-                  "label": "MuiButton-label-12",
-                  "mini": "MuiButton-mini-33",
-                  "outlined": "MuiButton-outlined-19",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary-20",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary-21",
-                  "raised": "MuiButton-raised-25",
-                  "raisedPrimary": "MuiButton-raisedPrimary-26",
-                  "raisedSecondary": "MuiButton-raisedSecondary-27",
-                  "root": "MuiButton-root-11",
-                  "sizeLarge": "MuiButton-sizeLarge-35",
-                  "sizeSmall": "MuiButton-sizeSmall-34",
-                  "text": "MuiButton-text-13",
-                  "textPrimary": "MuiButton-textPrimary-14",
-                  "textSecondary": "MuiButton-textSecondary-15",
-                }
-              }
-              color="default"
-              component="button"
-              disableFocusRipple={false}
-              disabled={false}
-              fullWidth={false}
-              mini={false}
-              onClick={[Function]}
-              size="medium"
-              type="button"
-              variant="text"
-            >
-              <WithStyles(ButtonBase)
-                className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button"
-                component="button"
-                disabled={false}
-                focusRipple={true}
-                focusVisibleClassName="MuiButton-focusVisible-30"
-                onClick={[Function]}
-                type="button"
-              >
-                <ButtonBase
-                  centerRipple={false}
-                  className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button"
-                  classes={
-                    Object {
-                      "disabled": "MuiButtonBase-disabled-38",
-                      "focusVisible": "MuiButtonBase-focusVisible-39",
-                      "root": "MuiButtonBase-root-37",
-                    }
-                  }
-                  component="button"
-                  disableRipple={false}
-                  disableTouchRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="MuiButton-focusVisible-30"
-                  onClick={[Function]}
-                  tabIndex="0"
-                  type="button"
-                >
-                  <button
-                    className="MuiButtonBase-root-37 MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex="0"
-                    type="button"
-                  >
-                    <span
-                      className="MuiButton-label-12"
-                    >
-                      <span>
-                        Overview
-                      </span>
-                    </span>
-                    <NoSsr
-                      defer={false}
-                      fallback={null}
-                    >
-                      <WithStyles(TouchRipple)
-                        center={false}
-                        innerRef={[Function]}
-                      >
-                        <TouchRipple
-                          center={false}
-                          classes={
-                            Object {
-                              "child": "MuiTouchRipple-child-53",
-                              "childLeaving": "MuiTouchRipple-childLeaving-54",
-                              "childPulsate": "MuiTouchRipple-childPulsate-55",
-                              "ripple": "MuiTouchRipple-ripple-50",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-52",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-51",
-                              "root": "MuiTouchRipple-root-49",
-                            }
-                          }
-                        >
-                          <TransitionGroup
-                            childFactory={[Function]}
-                            className="MuiTouchRipple-root-49"
-                            component="span"
-                            enter={true}
-                            exit={true}
-                          >
-                            <span
-                              className="MuiTouchRipple-root-49"
-                            />
-                          </TransitionGroup>
-                        </TouchRipple>
-                      </WithStyles(TouchRipple)>
-                    </NoSsr>
-                  </button>
-                </ButtonBase>
-              </WithStyles(ButtonBase)>
-            </Button>
-          </WithStyles(Button)>
-          <WithStyles(Button)
             className="button active"
-            key="1"
+            key="0"
             onClick={[Function]}
           >
             <Button
@@ -6719,6 +6576,149 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                       className="MuiButton-label-12"
                     >
                       <span>
+                        Overview
+                      </span>
+                    </span>
+                    <NoSsr
+                      defer={false}
+                      fallback={null}
+                    >
+                      <WithStyles(TouchRipple)
+                        center={false}
+                        innerRef={[Function]}
+                      >
+                        <TouchRipple
+                          center={false}
+                          classes={
+                            Object {
+                              "child": "MuiTouchRipple-child-44",
+                              "childLeaving": "MuiTouchRipple-childLeaving-45",
+                              "childPulsate": "MuiTouchRipple-childPulsate-46",
+                              "ripple": "MuiTouchRipple-ripple-41",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-43",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-42",
+                              "root": "MuiTouchRipple-root-40",
+                            }
+                          }
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            className="MuiTouchRipple-root-40"
+                            component="span"
+                            enter={true}
+                            exit={true}
+                          >
+                            <span
+                              className="MuiTouchRipple-root-40"
+                            />
+                          </TransitionGroup>
+                        </TouchRipple>
+                      </WithStyles(TouchRipple)>
+                    </NoSsr>
+                  </button>
+                </ButtonBase>
+              </WithStyles(ButtonBase)>
+            </Button>
+          </WithStyles(Button)>
+          <WithStyles(Button)
+            className="button"
+            key="1"
+            onClick={[Function]}
+          >
+            <Button
+              className="button"
+              classes={
+                Object {
+                  "colorInherit": "MuiButton-colorInherit-32",
+                  "contained": "MuiButton-contained-22",
+                  "containedPrimary": "MuiButton-containedPrimary-23",
+                  "containedSecondary": "MuiButton-containedSecondary-24",
+                  "disabled": "MuiButton-disabled-31",
+                  "extendedFab": "MuiButton-extendedFab-29",
+                  "fab": "MuiButton-fab-28",
+                  "flat": "MuiButton-flat-16",
+                  "flatPrimary": "MuiButton-flatPrimary-17",
+                  "flatSecondary": "MuiButton-flatSecondary-18",
+                  "focusVisible": "MuiButton-focusVisible-30",
+                  "fullWidth": "MuiButton-fullWidth-36",
+                  "label": "MuiButton-label-12",
+                  "mini": "MuiButton-mini-33",
+                  "outlined": "MuiButton-outlined-19",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-20",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-21",
+                  "raised": "MuiButton-raised-25",
+                  "raisedPrimary": "MuiButton-raisedPrimary-26",
+                  "raisedSecondary": "MuiButton-raisedSecondary-27",
+                  "root": "MuiButton-root-11",
+                  "sizeLarge": "MuiButton-sizeLarge-35",
+                  "sizeSmall": "MuiButton-sizeSmall-34",
+                  "text": "MuiButton-text-13",
+                  "textPrimary": "MuiButton-textPrimary-14",
+                  "textSecondary": "MuiButton-textSecondary-15",
+                }
+              }
+              color="default"
+              component="button"
+              disableFocusRipple={false}
+              disabled={false}
+              fullWidth={false}
+              mini={false}
+              onClick={[Function]}
+              size="medium"
+              type="button"
+              variant="text"
+            >
+              <WithStyles(ButtonBase)
+                className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button"
+                component="button"
+                disabled={false}
+                focusRipple={true}
+                focusVisibleClassName="MuiButton-focusVisible-30"
+                onClick={[Function]}
+                type="button"
+              >
+                <ButtonBase
+                  centerRipple={false}
+                  className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button"
+                  classes={
+                    Object {
+                      "disabled": "MuiButtonBase-disabled-38",
+                      "focusVisible": "MuiButtonBase-focusVisible-39",
+                      "root": "MuiButtonBase-root-37",
+                    }
+                  }
+                  component="button"
+                  disableRipple={false}
+                  disableTouchRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="MuiButton-focusVisible-30"
+                  onClick={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <button
+                    className="MuiButtonBase-root-37 MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 button"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onContextMenu={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <span
+                      className="MuiButton-label-12"
+                    >
+                      <span>
                         Lineage Explorer
                       </span>
                     </span>
@@ -6734,25 +6734,25 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                           center={false}
                           classes={
                             Object {
-                              "child": "MuiTouchRipple-child-53",
-                              "childLeaving": "MuiTouchRipple-childLeaving-54",
-                              "childPulsate": "MuiTouchRipple-childPulsate-55",
-                              "ripple": "MuiTouchRipple-ripple-50",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-52",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible-51",
-                              "root": "MuiTouchRipple-root-49",
+                              "child": "MuiTouchRipple-child-44",
+                              "childLeaving": "MuiTouchRipple-childLeaving-45",
+                              "childPulsate": "MuiTouchRipple-childPulsate-46",
+                              "ripple": "MuiTouchRipple-ripple-41",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-43",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-42",
+                              "root": "MuiTouchRipple-root-40",
                             }
                           }
                         >
                           <TransitionGroup
                             childFactory={[Function]}
-                            className="MuiTouchRipple-root-49"
+                            className="MuiTouchRipple-root-40"
                             component="span"
                             enter={true}
                             exit={true}
                           >
                             <span
-                              className="MuiTouchRipple-root-49"
+                              className="MuiTouchRipple-root-40"
                             />
                           </TransitionGroup>
                         </TouchRipple>
@@ -6766,82 +6766,17 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
         </div>
       </MD2Tabs>
     </div>
-    <LineageView
-      target={
-        Object {
-          "array": Array [
-            1,
-            1,
-            "gs://my-bucket/mnist",
-            Array [
+    <div
+      className=""
+    >
+      <ResourceInfo
+        resource={
+          Object {
+            "array": Array [
+              1,
+              1,
+              "gs://my-bucket/mnist",
               Array [
-                "__ALL_META__",
-                Array [
-                  undefined,
-                  undefined,
-                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                ],
-              ],
-              Array [
-                "create_time",
-                Array [
-                  undefined,
-                  undefined,
-                  "2019-06-12T01:21:48.259263Z",
-                ],
-              ],
-              Array [
-                "description",
-                Array [
-                  undefined,
-                  undefined,
-                  "A really great model",
-                ],
-              ],
-              Array [
-                "name",
-                Array [
-                  undefined,
-                  undefined,
-                  "test model",
-                ],
-              ],
-              Array [
-                "version",
-                Array [
-                  undefined,
-                  undefined,
-                  "v1",
-                ],
-              ],
-            ],
-            Array [
-              Array [
-                "__kf_run__",
-                Array [
-                  undefined,
-                  undefined,
-                  "1",
-                ],
-              ],
-              Array [
-                "__kf_workspace__",
-                Array [
-                  undefined,
-                  undefined,
-                  "workspace-1",
-                ],
-              ],
-            ],
-          ],
-          "arrayIndexOffset_": -1,
-          "convertedPrimitiveFields_": Object {},
-          "messageId_": undefined,
-          "pivot_": 1.7976931348623157e+308,
-          "wrappers_": Object {
-            "4": Object {
-              "arrClean": true,
-              "arr_": Array [
                 Array [
                   "__ALL_META__",
                   Array [
@@ -6883,113 +6818,7 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                   ],
                 ],
               ],
-              "map_": Object {
-                "__ALL_META__": Object {
-                  "key": "__ALL_META__",
-                  "value": Array [
-                    undefined,
-                    undefined,
-                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                  ],
-                  "valueWrapper": Object {
-                    "array": Array [
-                      undefined,
-                      undefined,
-                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                    ],
-                    "arrayIndexOffset_": -1,
-                    "convertedPrimitiveFields_": Object {},
-                    "messageId_": undefined,
-                    "pivot_": 1.7976931348623157e+308,
-                    "wrappers_": null,
-                  },
-                },
-                "create_time": Object {
-                  "key": "create_time",
-                  "value": Array [
-                    undefined,
-                    undefined,
-                    "2019-06-12T01:21:48.259263Z",
-                  ],
-                  "valueWrapper": Object {
-                    "array": Array [
-                      undefined,
-                      undefined,
-                      "2019-06-12T01:21:48.259263Z",
-                    ],
-                    "arrayIndexOffset_": -1,
-                    "convertedPrimitiveFields_": Object {},
-                    "messageId_": undefined,
-                    "pivot_": 1.7976931348623157e+308,
-                    "wrappers_": null,
-                  },
-                },
-                "description": Object {
-                  "key": "description",
-                  "value": Array [
-                    undefined,
-                    undefined,
-                    "A really great model",
-                  ],
-                  "valueWrapper": Object {
-                    "array": Array [
-                      undefined,
-                      undefined,
-                      "A really great model",
-                    ],
-                    "arrayIndexOffset_": -1,
-                    "convertedPrimitiveFields_": Object {},
-                    "messageId_": undefined,
-                    "pivot_": 1.7976931348623157e+308,
-                    "wrappers_": null,
-                  },
-                },
-                "name": Object {
-                  "key": "name",
-                  "value": Array [
-                    undefined,
-                    undefined,
-                    "test model",
-                  ],
-                  "valueWrapper": Object {
-                    "array": Array [
-                      undefined,
-                      undefined,
-                      "test model",
-                    ],
-                    "arrayIndexOffset_": -1,
-                    "convertedPrimitiveFields_": Object {},
-                    "messageId_": undefined,
-                    "pivot_": 1.7976931348623157e+308,
-                    "wrappers_": null,
-                  },
-                },
-                "version": Object {
-                  "key": "version",
-                  "value": Array [
-                    undefined,
-                    undefined,
-                    "v1",
-                  ],
-                  "valueWrapper": Object {
-                    "array": Array [
-                      undefined,
-                      undefined,
-                      "v1",
-                    ],
-                    "arrayIndexOffset_": -1,
-                    "convertedPrimitiveFields_": Object {},
-                    "messageId_": undefined,
-                    "pivot_": 1.7976931348623157e+308,
-                    "wrappers_": null,
-                  },
-                },
-              },
-              "valueCtor_": [Function],
-            },
-            "5": Object {
-              "arrClean": true,
-              "arr_": Array [
+              Array [
                 Array [
                   "__kf_run__",
                   Array [
@@ -7007,65 +6836,15 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                   ],
                 ],
               ],
-              "map_": Object {
-                "__kf_run__": Object {
-                  "key": "__kf_run__",
-                  "value": Array [
-                    undefined,
-                    undefined,
-                    "1",
-                  ],
-                  "valueWrapper": Object {
-                    "array": Array [
-                      undefined,
-                      undefined,
-                      "1",
-                    ],
-                    "arrayIndexOffset_": -1,
-                    "convertedPrimitiveFields_": Object {},
-                    "messageId_": undefined,
-                    "pivot_": 1.7976931348623157e+308,
-                    "wrappers_": null,
-                  },
-                },
-                "__kf_workspace__": Object {
-                  "key": "__kf_workspace__",
-                  "value": Array [
-                    undefined,
-                    undefined,
-                    "workspace-1",
-                  ],
-                  "valueWrapper": Object {
-                    "array": Array [
-                      undefined,
-                      undefined,
-                      "workspace-1",
-                    ],
-                    "arrayIndexOffset_": -1,
-                    "convertedPrimitiveFields_": Object {},
-                    "messageId_": undefined,
-                    "pivot_": 1.7976931348623157e+308,
-                    "wrappers_": null,
-                  },
-                },
-              },
-              "valueCtor_": [Function],
-            },
-          },
-        }
-      }
-    >
-      <div
-        className="page"
-      >
-        <LineageActionBar
-          initialTarget={
-            Object {
-              "array": Array [
-                1,
-                1,
-                "gs://my-bucket/mnist",
-                Array [
+            ],
+            "arrayIndexOffset_": -1,
+            "convertedPrimitiveFields_": Object {},
+            "messageId_": undefined,
+            "pivot_": 1.7976931348623157e+308,
+            "wrappers_": Object {
+              "4": Object {
+                "arrClean": true,
+                "arr_": Array [
                   Array [
                     "__ALL_META__",
                     Array [
@@ -7107,7 +6886,113 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                     ],
                   ],
                 ],
-                Array [
+                "map_": Object {
+                  "__ALL_META__": Object {
+                    "key": "__ALL_META__",
+                    "value": Array [
+                      undefined,
+                      undefined,
+                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                    ],
+                    "valueWrapper": Object {
+                      "array": Array [
+                        undefined,
+                        undefined,
+                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
+                      ],
+                      "arrayIndexOffset_": -1,
+                      "convertedPrimitiveFields_": Object {},
+                      "messageId_": undefined,
+                      "pivot_": 1.7976931348623157e+308,
+                      "wrappers_": null,
+                    },
+                  },
+                  "create_time": Object {
+                    "key": "create_time",
+                    "value": Array [
+                      undefined,
+                      undefined,
+                      "2019-06-12T01:21:48.259263Z",
+                    ],
+                    "valueWrapper": Object {
+                      "array": Array [
+                        undefined,
+                        undefined,
+                        "2019-06-12T01:21:48.259263Z",
+                      ],
+                      "arrayIndexOffset_": -1,
+                      "convertedPrimitiveFields_": Object {},
+                      "messageId_": undefined,
+                      "pivot_": 1.7976931348623157e+308,
+                      "wrappers_": null,
+                    },
+                  },
+                  "description": Object {
+                    "key": "description",
+                    "value": Array [
+                      undefined,
+                      undefined,
+                      "A really great model",
+                    ],
+                    "valueWrapper": Object {
+                      "array": Array [
+                        undefined,
+                        undefined,
+                        "A really great model",
+                      ],
+                      "arrayIndexOffset_": -1,
+                      "convertedPrimitiveFields_": Object {},
+                      "messageId_": undefined,
+                      "pivot_": 1.7976931348623157e+308,
+                      "wrappers_": null,
+                    },
+                  },
+                  "name": Object {
+                    "key": "name",
+                    "value": Array [
+                      undefined,
+                      undefined,
+                      "test model",
+                    ],
+                    "valueWrapper": Object {
+                      "array": Array [
+                        undefined,
+                        undefined,
+                        "test model",
+                      ],
+                      "arrayIndexOffset_": -1,
+                      "convertedPrimitiveFields_": Object {},
+                      "messageId_": undefined,
+                      "pivot_": 1.7976931348623157e+308,
+                      "wrappers_": null,
+                    },
+                  },
+                  "version": Object {
+                    "key": "version",
+                    "value": Array [
+                      undefined,
+                      undefined,
+                      "v1",
+                    ],
+                    "valueWrapper": Object {
+                      "array": Array [
+                        undefined,
+                        undefined,
+                        "v1",
+                      ],
+                      "arrayIndexOffset_": -1,
+                      "convertedPrimitiveFields_": Object {},
+                      "messageId_": undefined,
+                      "pivot_": 1.7976931348623157e+308,
+                      "wrappers_": null,
+                    },
+                  },
+                },
+                "valueCtor_": [Function],
+              },
+              "5": Object {
+                "arrClean": true,
+                "arr_": Array [
                   Array [
                     "__kf_run__",
                     Array [
@@ -7125,4825 +7010,173 @@ exports[`ArtifactDetails Renders with a Model Artifact and updates the page titl
                     ],
                   ],
                 ],
-              ],
-              "arrayIndexOffset_": -1,
-              "convertedPrimitiveFields_": Object {},
-              "messageId_": undefined,
-              "pivot_": 1.7976931348623157e+308,
-              "wrappers_": Object {
-                "4": Object {
-                  "arrClean": true,
-                  "arr_": Array [
-                    Array [
-                      "__ALL_META__",
-                      Array [
-                        undefined,
-                        undefined,
-                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                      ],
+                "map_": Object {
+                  "__kf_run__": Object {
+                    "key": "__kf_run__",
+                    "value": Array [
+                      undefined,
+                      undefined,
+                      "1",
                     ],
-                    Array [
-                      "create_time",
-                      Array [
-                        undefined,
-                        undefined,
-                        "2019-06-12T01:21:48.259263Z",
-                      ],
-                    ],
-                    Array [
-                      "description",
-                      Array [
-                        undefined,
-                        undefined,
-                        "A really great model",
-                      ],
-                    ],
-                    Array [
-                      "name",
-                      Array [
-                        undefined,
-                        undefined,
-                        "test model",
-                      ],
-                    ],
-                    Array [
-                      "version",
-                      Array [
-                        undefined,
-                        undefined,
-                        "v1",
-                      ],
-                    ],
-                  ],
-                  "map_": Object {
-                    "__ALL_META__": Object {
-                      "key": "__ALL_META__",
-                      "value": Array [
-                        undefined,
-                        undefined,
-                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                      ],
-                      "valueWrapper": Object {
-                        "array": Array [
-                          undefined,
-                          undefined,
-                          "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": null,
-                      },
-                    },
-                    "create_time": Object {
-                      "key": "create_time",
-                      "value": Array [
-                        undefined,
-                        undefined,
-                        "2019-06-12T01:21:48.259263Z",
-                      ],
-                      "valueWrapper": Object {
-                        "array": Array [
-                          undefined,
-                          undefined,
-                          "2019-06-12T01:21:48.259263Z",
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": null,
-                      },
-                    },
-                    "description": Object {
-                      "key": "description",
-                      "value": Array [
-                        undefined,
-                        undefined,
-                        "A really great model",
-                      ],
-                      "valueWrapper": Object {
-                        "array": Array [
-                          undefined,
-                          undefined,
-                          "A really great model",
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": null,
-                      },
-                    },
-                    "name": Object {
-                      "key": "name",
-                      "value": Array [
-                        undefined,
-                        undefined,
-                        "test model",
-                      ],
-                      "valueWrapper": Object {
-                        "array": Array [
-                          undefined,
-                          undefined,
-                          "test model",
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": null,
-                      },
-                    },
-                    "version": Object {
-                      "key": "version",
-                      "value": Array [
-                        undefined,
-                        undefined,
-                        "v1",
-                      ],
-                      "valueWrapper": Object {
-                        "array": Array [
-                          undefined,
-                          undefined,
-                          "v1",
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": null,
-                      },
-                    },
-                  },
-                  "valueCtor_": [Function],
-                },
-                "5": Object {
-                  "arrClean": true,
-                  "arr_": Array [
-                    Array [
-                      "__kf_run__",
-                      Array [
+                    "valueWrapper": Object {
+                      "array": Array [
                         undefined,
                         undefined,
                         "1",
                       ],
-                    ],
-                    Array [
-                      "__kf_workspace__",
-                      Array [
-                        undefined,
-                        undefined,
-                        "workspace-1",
-                      ],
-                    ],
-                  ],
-                  "map_": Object {
-                    "__kf_run__": Object {
-                      "key": "__kf_run__",
-                      "value": Array [
-                        undefined,
-                        undefined,
-                        "1",
-                      ],
-                      "valueWrapper": Object {
-                        "array": Array [
-                          undefined,
-                          undefined,
-                          "1",
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": null,
-                      },
-                    },
-                    "__kf_workspace__": Object {
-                      "key": "__kf_workspace__",
-                      "value": Array [
-                        undefined,
-                        undefined,
-                        "workspace-1",
-                      ],
-                      "valueWrapper": Object {
-                        "array": Array [
-                          undefined,
-                          undefined,
-                          "workspace-1",
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": null,
-                      },
+                      "arrayIndexOffset_": -1,
+                      "convertedPrimitiveFields_": Object {},
+                      "messageId_": undefined,
+                      "pivot_": 1.7976931348623157e+308,
+                      "wrappers_": null,
                     },
                   },
-                  "valueCtor_": [Function],
+                  "__kf_workspace__": Object {
+                    "key": "__kf_workspace__",
+                    "value": Array [
+                      undefined,
+                      undefined,
+                      "workspace-1",
+                    ],
+                    "valueWrapper": Object {
+                      "array": Array [
+                        undefined,
+                        undefined,
+                        "workspace-1",
+                      ],
+                      "arrayIndexOffset_": -1,
+                      "convertedPrimitiveFields_": Object {},
+                      "messageId_": undefined,
+                      "pivot_": 1.7976931348623157e+308,
+                      "wrappers_": null,
+                    },
+                  },
                 },
+                "valueCtor_": [Function],
               },
-            }
+            },
           }
-          setLineageViewTarget={[Function]}
-        >
-          <div
-            className="container flex"
+        }
+        typeName="Model"
+      >
+        <section>
+          <h1
+            className="header"
+          >
+            Type: 
+            Model
+          </h1>
+          <h2
+            className="header2"
+          >
+            Properties
+          </h2>
+          <dl
+            className="resourceInfo"
           >
             <div
-              className="flex"
+              className="field"
+              key="create_time"
             >
-              <button
-                className="breadcrumbActive"
-                disabled={true}
-                key="breadcrumb-0"
-                onClick={[Function]}
+              <dt
+                className="term"
+              >
+                create_time
+              </dt>
+              <dd
+                className="value"
+              >
+                2019-06-12T01:21:48.259263Z
+              </dd>
+            </div>
+            <div
+              className="field"
+              key="description"
+            >
+              <dt
+                className="term"
+              >
+                description
+              </dt>
+              <dd
+                className="value"
+              >
+                A really great model
+              </dd>
+            </div>
+            <div
+              className="field"
+              key="name"
+            >
+              <dt
+                className="term"
+              >
+                name
+              </dt>
+              <dd
+                className="value"
               >
                 test model
-              </button>
+              </dd>
             </div>
-            <div>
-              <WithStyles(Button)
-                className="actionButton"
-                disabled={false}
-                onClick={[Function]}
+            <div
+              className="field"
+              key="version"
+            >
+              <dt
+                className="term"
               >
-                <Button
-                  className="actionButton"
-                  classes={
-                    Object {
-                      "colorInherit": "MuiButton-colorInherit-32",
-                      "contained": "MuiButton-contained-22",
-                      "containedPrimary": "MuiButton-containedPrimary-23",
-                      "containedSecondary": "MuiButton-containedSecondary-24",
-                      "disabled": "MuiButton-disabled-31",
-                      "extendedFab": "MuiButton-extendedFab-29",
-                      "fab": "MuiButton-fab-28",
-                      "flat": "MuiButton-flat-16",
-                      "flatPrimary": "MuiButton-flatPrimary-17",
-                      "flatSecondary": "MuiButton-flatSecondary-18",
-                      "focusVisible": "MuiButton-focusVisible-30",
-                      "fullWidth": "MuiButton-fullWidth-36",
-                      "label": "MuiButton-label-12",
-                      "mini": "MuiButton-mini-33",
-                      "outlined": "MuiButton-outlined-19",
-                      "outlinedPrimary": "MuiButton-outlinedPrimary-20",
-                      "outlinedSecondary": "MuiButton-outlinedSecondary-21",
-                      "raised": "MuiButton-raised-25",
-                      "raisedPrimary": "MuiButton-raisedPrimary-26",
-                      "raisedSecondary": "MuiButton-raisedSecondary-27",
-                      "root": "MuiButton-root-11",
-                      "sizeLarge": "MuiButton-sizeLarge-35",
-                      "sizeSmall": "MuiButton-sizeSmall-34",
-                      "text": "MuiButton-text-13",
-                      "textPrimary": "MuiButton-textPrimary-14",
-                      "textSecondary": "MuiButton-textSecondary-15",
-                    }
-                  }
-                  color="default"
-                  component="button"
-                  disableFocusRipple={false}
-                  disabled={false}
-                  fullWidth={false}
-                  mini={false}
-                  onClick={[Function]}
-                  size="medium"
-                  type="button"
-                  variant="text"
-                >
-                  <WithStyles(ButtonBase)
-                    className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 actionButton"
-                    component="button"
-                    disabled={false}
-                    focusRipple={true}
-                    focusVisibleClassName="MuiButton-focusVisible-30"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <ButtonBase
-                      centerRipple={false}
-                      className="MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 actionButton"
-                      classes={
-                        Object {
-                          "disabled": "MuiButtonBase-disabled-38",
-                          "focusVisible": "MuiButtonBase-focusVisible-39",
-                          "root": "MuiButtonBase-root-37",
-                        }
-                      }
-                      component="button"
-                      disableRipple={false}
-                      disableTouchRipple={false}
-                      disabled={false}
-                      focusRipple={true}
-                      focusVisibleClassName="MuiButton-focusVisible-30"
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <button
-                        className="MuiButtonBase-root-37 MuiButton-root-11 MuiButton-text-13 MuiButton-flat-16 actionButton"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onContextMenu={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchMove={[Function]}
-                        onTouchStart={[Function]}
-                        tabIndex="0"
-                        type="button"
-                      >
-                        <span
-                          className="MuiButton-label-12"
-                        >
-                          <pure(ReplayIcon)>
-                            <ReplayIcon>
-                              <WithStyles(SvgIcon)>
-                                <SvgIcon
-                                  classes={
-                                    Object {
-                                      "colorAction": "MuiSvgIcon-colorAction-43",
-                                      "colorDisabled": "MuiSvgIcon-colorDisabled-45",
-                                      "colorError": "MuiSvgIcon-colorError-44",
-                                      "colorPrimary": "MuiSvgIcon-colorPrimary-41",
-                                      "colorSecondary": "MuiSvgIcon-colorSecondary-42",
-                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-46",
-                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-48",
-                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-47",
-                                      "root": "MuiSvgIcon-root-40",
-                                    }
-                                  }
-                                  color="inherit"
-                                  component="svg"
-                                  fontSize="default"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    className="MuiSvgIcon-root-40"
-                                    focusable="false"
-                                    role="presentation"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      d="M0 0h24v24H0z"
-                                      fill="none"
-                                    />
-                                    <path
-                                      d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
-                                    />
-                                  </svg>
-                                </SvgIcon>
-                              </WithStyles(SvgIcon)>
-                            </ReplayIcon>
-                          </pure(ReplayIcon)>
-                           Reset
-                        </span>
-                        <NoSsr
-                          defer={false}
-                          fallback={null}
-                        >
-                          <WithStyles(TouchRipple)
-                            center={false}
-                            innerRef={[Function]}
-                          >
-                            <TouchRipple
-                              center={false}
-                              classes={
-                                Object {
-                                  "child": "MuiTouchRipple-child-53",
-                                  "childLeaving": "MuiTouchRipple-childLeaving-54",
-                                  "childPulsate": "MuiTouchRipple-childPulsate-55",
-                                  "ripple": "MuiTouchRipple-ripple-50",
-                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-52",
-                                  "rippleVisible": "MuiTouchRipple-rippleVisible-51",
-                                  "root": "MuiTouchRipple-root-49",
-                                }
-                              }
-                            >
-                              <TransitionGroup
-                                childFactory={[Function]}
-                                className="MuiTouchRipple-root-49"
-                                component="span"
-                                enter={true}
-                                exit={true}
-                              >
-                                <span
-                                  className="MuiTouchRipple-root-49"
-                                />
-                              </TransitionGroup>
-                            </TouchRipple>
-                          </WithStyles(TouchRipple)>
-                        </NoSsr>
-                      </button>
-                    </ButtonBase>
-                  </WithStyles(ButtonBase)>
-                </Button>
-              </WithStyles(Button)>
+                version
+              </dt>
+              <dd
+                className="value"
+              >
+                v1
+              </dd>
             </div>
-          </div>
-        </LineageActionBar>
-        <div
-          className="page LineageExplorer"
-          style={
-            Object {
-              "background": "#f3f2f4",
-              "flexFlow": "row",
-              "overflow": "auto",
-              "position": "relative",
-              "width": "100%",
-              "zIndex": 0,
-            }
-          }
-        >
-          <LineageCardColumn
-            cards={
-              Array [
-                Object {
-                  "elements": Array [
-                    Object {
-                      "next": true,
-                      "prev": true,
-                      "resource": Object {
-                        "array": Array [
-                          1,
-                          1,
-                          "gs://my-bucket/mnist",
-                          Array [
-                            Array [
-                              "__ALL_META__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                              ],
-                            ],
-                            Array [
-                              "create_time",
-                              Array [
-                                undefined,
-                                undefined,
-                                "2019-06-12T01:21:48.259263Z",
-                              ],
-                            ],
-                            Array [
-                              "description",
-                              Array [
-                                undefined,
-                                undefined,
-                                "A really great model",
-                              ],
-                            ],
-                            Array [
-                              "name",
-                              Array [
-                                undefined,
-                                undefined,
-                                "test model",
-                              ],
-                            ],
-                            Array [
-                              "version",
-                              Array [
-                                undefined,
-                                undefined,
-                                "v1",
-                              ],
-                            ],
-                          ],
-                          Array [
-                            Array [
-                              "__kf_run__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "1",
-                              ],
-                            ],
-                            Array [
-                              "__kf_workspace__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "workspace-1",
-                              ],
-                            ],
-                          ],
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": Object {
-                          "4": Object {
-                            "arrClean": true,
-                            "arr_": Array [
-                              Array [
-                                "__ALL_META__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                              ],
-                              Array [
-                                "create_time",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                              ],
-                              Array [
-                                "description",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                              ],
-                              Array [
-                                "name",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                              ],
-                              Array [
-                                "version",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                              ],
-                            ],
-                            "map_": Object {
-                              "__ALL_META__": Object {
-                                "key": "__ALL_META__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "create_time": Object {
-                                "key": "create_time",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "description": Object {
-                                "key": "description",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "name": Object {
-                                "key": "name",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "version": Object {
-                                "key": "version",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                            },
-                            "valueCtor_": [Function],
-                          },
-                          "5": Object {
-                            "arrClean": true,
-                            "arr_": Array [
-                              Array [
-                                "__kf_run__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                              ],
-                              Array [
-                                "__kf_workspace__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                              ],
-                            ],
-                            "map_": Object {
-                              "__kf_run__": Object {
-                                "key": "__kf_run__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "__kf_workspace__": Object {
-                                "key": "__kf_workspace__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                            },
-                            "valueCtor_": [Function],
-                          },
-                        },
-                      },
-                    },
-                  ],
-                  "title": "Artifact",
-                },
-              ]
-            }
-            setLineageViewTarget={[Function]}
-            title="Input Artifact"
-            type="artifact"
+          </dl>
+          <h2
+            className="header2"
+          >
+            Custom Properties
+          </h2>
+          <dl
+            className="resourceInfo"
           >
             <div
-              className="mainColumn artifact"
+              className="field"
+              key="__kf_run__"
             >
-              <div
-                className="columnHeader"
+              <dt
+                className="term"
               >
-                <h2>
-                  Input Artifact
-                </h2>
-              </div>
-              <div
-                className="columnBody"
+                __kf_run__
+              </dt>
+              <dd
+                className="value"
               >
-                <EdgeCanvas
-                  cardArray={
-                    Array [
-                      1,
-                    ]
-                  }
-                  reverseEdges={false}
-                  type="artifact"
-                >
-                  <div
-                    className="edgeCanvas"
-                  >
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 0,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="0-0"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={1}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 1"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 1"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                  </div>
-                </EdgeCanvas>
-                <LineageCard
-                  addSpacer={false}
-                  isTarget={false}
-                  key="0"
-                  rows={
-                    Array [
-                      Object {
-                        "next": true,
-                        "prev": true,
-                        "resource": Object {
-                          "array": Array [
-                            1,
-                            1,
-                            "gs://my-bucket/mnist",
-                            Array [
-                              Array [
-                                "__ALL_META__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                              ],
-                              Array [
-                                "create_time",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                              ],
-                              Array [
-                                "description",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                              ],
-                              Array [
-                                "name",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                              ],
-                              Array [
-                                "version",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                              ],
-                            ],
-                            Array [
-                              Array [
-                                "__kf_run__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                              ],
-                              Array [
-                                "__kf_workspace__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                              ],
-                            ],
-                          ],
-                          "arrayIndexOffset_": -1,
-                          "convertedPrimitiveFields_": Object {},
-                          "messageId_": undefined,
-                          "pivot_": 1.7976931348623157e+308,
-                          "wrappers_": Object {
-                            "4": Object {
-                              "arrClean": true,
-                              "arr_": Array [
-                                Array [
-                                  "__ALL_META__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                ],
-                                Array [
-                                  "create_time",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                ],
-                                Array [
-                                  "description",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                ],
-                                Array [
-                                  "name",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                ],
-                                Array [
-                                  "version",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                ],
-                              ],
-                              "map_": Object {
-                                "__ALL_META__": Object {
-                                  "key": "__ALL_META__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "create_time": Object {
-                                  "key": "create_time",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "description": Object {
-                                  "key": "description",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "name": Object {
-                                  "key": "name",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "version": Object {
-                                  "key": "version",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                              },
-                              "valueCtor_": [Function],
-                            },
-                            "5": Object {
-                              "arrClean": true,
-                              "arr_": Array [
-                                Array [
-                                  "__kf_run__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                ],
-                                Array [
-                                  "__kf_workspace__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                ],
-                              ],
-                              "map_": Object {
-                                "__kf_run__": Object {
-                                  "key": "__kf_run__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "__kf_workspace__": Object {
-                                  "key": "__kf_workspace__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                              },
-                              "valueCtor_": [Function],
-                            },
-                          },
-                        },
-                      },
-                    ]
-                  }
-                  setLineageViewTarget={[Function]}
-                  title="Artifact"
-                  type="artifact"
-                >
-                  <div
-                    className="cardContainer artifact"
-                  >
-                    <div
-                      className="cardTitle"
-                    >
-                      <h3>
-                        Artifact
-                      </h3>
-                    </div>
-                    <div
-                      className="cardBody"
-                    >
-                      <LineageCardRow
-                        hideRadio={false}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
-                        resource={
-                          Object {
-                            "array": Array [
-                              1,
-                              1,
-                              "gs://my-bucket/mnist",
-                              Array [
-                                Array [
-                                  "__ALL_META__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                ],
-                                Array [
-                                  "create_time",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                ],
-                                Array [
-                                  "description",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                ],
-                                Array [
-                                  "name",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                ],
-                                Array [
-                                  "version",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                ],
-                              ],
-                              Array [
-                                Array [
-                                  "__kf_run__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                ],
-                                Array [
-                                  "__kf_workspace__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                ],
-                              ],
-                            ],
-                            "arrayIndexOffset_": -1,
-                            "convertedPrimitiveFields_": Object {},
-                            "messageId_": undefined,
-                            "pivot_": 1.7976931348623157e+308,
-                            "wrappers_": Object {
-                              "4": Object {
-                                "arrClean": true,
-                                "arr_": Array [
-                                  Array [
-                                    "__ALL_META__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                  ],
-                                  Array [
-                                    "create_time",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                  ],
-                                  Array [
-                                    "description",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                  ],
-                                  Array [
-                                    "name",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                  ],
-                                  Array [
-                                    "version",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                  ],
-                                ],
-                                "map_": Object {
-                                  "__ALL_META__": Object {
-                                    "key": "__ALL_META__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "create_time": Object {
-                                    "key": "create_time",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "2019-06-12T01:21:48.259263Z",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "description": Object {
-                                    "key": "description",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "A really great model",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "name": Object {
-                                    "key": "name",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "test model",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "version": Object {
-                                    "key": "version",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "v1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                },
-                                "valueCtor_": [Function],
-                              },
-                              "5": Object {
-                                "arrClean": true,
-                                "arr_": Array [
-                                  Array [
-                                    "__kf_run__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                  ],
-                                  Array [
-                                    "__kf_workspace__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                  ],
-                                ],
-                                "map_": Object {
-                                  "__kf_run__": Object {
-                                    "key": "__kf_run__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "__kf_workspace__": Object {
-                                    "key": "__kf_workspace__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "workspace-1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                },
-                                "valueCtor_": [Function],
-                              },
-                            },
-                          }
-                        }
-                        rightAffordance={true}
-                        setLineageViewTarget={[Function]}
-                      >
-                        <div
-                          className="cardRow lastRow"
-                        >
-                          <div>
-                            <input
-                              className="form-radio"
-                              name=""
-                              onClick={[Function]}
-                              type="radio"
-                              value=""
-                            />
-                          </div>
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              test model
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              workspace-1
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeLeft"
-                            key="edgeLeft"
-                          />
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                    </div>
-                  </div>
-                </LineageCard>
-              </div>
+                1
+              </dd>
             </div>
-          </LineageCardColumn>
-          <LineageCardColumn
-            cards={
-              Array [
-                Object {
-                  "elements": Array [],
-                  "title": "Execution",
-                },
-              ]
-            }
-            title=""
-            type="execution"
-          >
             <div
-              className="mainColumn execution"
+              className="field"
+              key="__kf_workspace__"
             >
-              <div
-                className="columnHeader"
+              <dt
+                className="term"
               >
-                <h2 />
-              </div>
-              <div
-                className="columnBody"
+                __kf_workspace__
+              </dt>
+              <dd
+                className="value"
               >
-                <EdgeCanvas
-                  cardArray={
-                    Array [
-                      0,
-                    ]
-                  }
-                  reverseEdges={false}
-                  type="execution"
-                >
-                  <div
-                    className="edgeCanvas"
-                  />
-                </EdgeCanvas>
-                <LineageCard
-                  addSpacer={false}
-                  isTarget={false}
-                  key="0"
-                  rows={Array []}
-                  title="Execution"
-                  type="execution"
-                >
-                  <div
-                    className="cardContainer execution"
-                  >
-                    <div
-                      className="cardTitle"
-                    >
-                      <h3>
-                        Execution
-                      </h3>
-                    </div>
-                    <div
-                      className="cardBody"
-                    />
-                  </div>
-                </LineageCard>
-              </div>
+                workspace-1
+              </dd>
             </div>
-          </LineageCardColumn>
-          <LineageCardColumn
-            cards={
-              Array [
-                Object {
-                  "elements": Array [
-                    Object {
-                      "next": true,
-                      "prev": true,
-                      "resource": Object {
-                        "array": Array [
-                          1,
-                          1,
-                          "gs://my-bucket/mnist",
-                          Array [
-                            Array [
-                              "__ALL_META__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                              ],
-                            ],
-                            Array [
-                              "create_time",
-                              Array [
-                                undefined,
-                                undefined,
-                                "2019-06-12T01:21:48.259263Z",
-                              ],
-                            ],
-                            Array [
-                              "description",
-                              Array [
-                                undefined,
-                                undefined,
-                                "A really great model",
-                              ],
-                            ],
-                            Array [
-                              "name",
-                              Array [
-                                undefined,
-                                undefined,
-                                "test model",
-                              ],
-                            ],
-                            Array [
-                              "version",
-                              Array [
-                                undefined,
-                                undefined,
-                                "v1",
-                              ],
-                            ],
-                          ],
-                          Array [
-                            Array [
-                              "__kf_run__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "1",
-                              ],
-                            ],
-                            Array [
-                              "__kf_workspace__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "workspace-1",
-                              ],
-                            ],
-                          ],
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": Object {
-                          "4": Object {
-                            "arrClean": true,
-                            "arr_": Array [
-                              Array [
-                                "__ALL_META__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                              ],
-                              Array [
-                                "create_time",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                              ],
-                              Array [
-                                "description",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                              ],
-                              Array [
-                                "name",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                              ],
-                              Array [
-                                "version",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                              ],
-                            ],
-                            "map_": Object {
-                              "__ALL_META__": Object {
-                                "key": "__ALL_META__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "create_time": Object {
-                                "key": "create_time",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "description": Object {
-                                "key": "description",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "name": Object {
-                                "key": "name",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "version": Object {
-                                "key": "version",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                            },
-                            "valueCtor_": [Function],
-                          },
-                          "5": Object {
-                            "arrClean": true,
-                            "arr_": Array [
-                              Array [
-                                "__kf_run__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                              ],
-                              Array [
-                                "__kf_workspace__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                              ],
-                            ],
-                            "map_": Object {
-                              "__kf_run__": Object {
-                                "key": "__kf_run__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "__kf_workspace__": Object {
-                                "key": "__kf_workspace__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                            },
-                            "valueCtor_": [Function],
-                          },
-                        },
-                      },
-                    },
-                  ],
-                  "title": "Artifact",
-                },
-              ]
-            }
-            title="Target"
-            type="artifact"
-          >
-            <div
-              className="mainColumn artifact"
-            >
-              <div
-                className="columnHeader"
-              >
-                <h2>
-                  Target
-                </h2>
-              </div>
-              <div
-                className="columnBody"
-              >
-                <EdgeCanvas
-                  cardArray={
-                    Array [
-                      1,
-                    ]
-                  }
-                  reverseEdges={false}
-                  type="artifact"
-                >
-                  <div
-                    className="edgeCanvas"
-                  >
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 0,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="0-0"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={1}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 1"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 1"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                  </div>
-                </EdgeCanvas>
-                <LineageCard
-                  addSpacer={false}
-                  isTarget={true}
-                  key="0"
-                  rows={
-                    Array [
-                      Object {
-                        "next": true,
-                        "prev": true,
-                        "resource": Object {
-                          "array": Array [
-                            1,
-                            1,
-                            "gs://my-bucket/mnist",
-                            Array [
-                              Array [
-                                "__ALL_META__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                              ],
-                              Array [
-                                "create_time",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                              ],
-                              Array [
-                                "description",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                              ],
-                              Array [
-                                "name",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                              ],
-                              Array [
-                                "version",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                              ],
-                            ],
-                            Array [
-                              Array [
-                                "__kf_run__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                              ],
-                              Array [
-                                "__kf_workspace__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                              ],
-                            ],
-                          ],
-                          "arrayIndexOffset_": -1,
-                          "convertedPrimitiveFields_": Object {},
-                          "messageId_": undefined,
-                          "pivot_": 1.7976931348623157e+308,
-                          "wrappers_": Object {
-                            "4": Object {
-                              "arrClean": true,
-                              "arr_": Array [
-                                Array [
-                                  "__ALL_META__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                ],
-                                Array [
-                                  "create_time",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                ],
-                                Array [
-                                  "description",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                ],
-                                Array [
-                                  "name",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                ],
-                                Array [
-                                  "version",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                ],
-                              ],
-                              "map_": Object {
-                                "__ALL_META__": Object {
-                                  "key": "__ALL_META__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "create_time": Object {
-                                  "key": "create_time",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "description": Object {
-                                  "key": "description",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "name": Object {
-                                  "key": "name",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "version": Object {
-                                  "key": "version",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                              },
-                              "valueCtor_": [Function],
-                            },
-                            "5": Object {
-                              "arrClean": true,
-                              "arr_": Array [
-                                Array [
-                                  "__kf_run__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                ],
-                                Array [
-                                  "__kf_workspace__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                ],
-                              ],
-                              "map_": Object {
-                                "__kf_run__": Object {
-                                  "key": "__kf_run__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "__kf_workspace__": Object {
-                                  "key": "__kf_workspace__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                              },
-                              "valueCtor_": [Function],
-                            },
-                          },
-                        },
-                      },
-                    ]
-                  }
-                  title="Artifact"
-                  type="artifact"
-                >
-                  <div
-                    className="cardContainer artifact target"
-                  >
-                    <div
-                      className="cardTitle"
-                    >
-                      <h3>
-                        Artifact
-                      </h3>
-                    </div>
-                    <div
-                      className="cardBody"
-                    >
-                      <LineageCardRow
-                        hideRadio={true}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
-                        resource={
-                          Object {
-                            "array": Array [
-                              1,
-                              1,
-                              "gs://my-bucket/mnist",
-                              Array [
-                                Array [
-                                  "__ALL_META__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                ],
-                                Array [
-                                  "create_time",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                ],
-                                Array [
-                                  "description",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                ],
-                                Array [
-                                  "name",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                ],
-                                Array [
-                                  "version",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                ],
-                              ],
-                              Array [
-                                Array [
-                                  "__kf_run__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                ],
-                                Array [
-                                  "__kf_workspace__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                ],
-                              ],
-                            ],
-                            "arrayIndexOffset_": -1,
-                            "convertedPrimitiveFields_": Object {},
-                            "messageId_": undefined,
-                            "pivot_": 1.7976931348623157e+308,
-                            "wrappers_": Object {
-                              "4": Object {
-                                "arrClean": true,
-                                "arr_": Array [
-                                  Array [
-                                    "__ALL_META__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                  ],
-                                  Array [
-                                    "create_time",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                  ],
-                                  Array [
-                                    "description",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                  ],
-                                  Array [
-                                    "name",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                  ],
-                                  Array [
-                                    "version",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                  ],
-                                ],
-                                "map_": Object {
-                                  "__ALL_META__": Object {
-                                    "key": "__ALL_META__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "create_time": Object {
-                                    "key": "create_time",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "2019-06-12T01:21:48.259263Z",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "description": Object {
-                                    "key": "description",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "A really great model",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "name": Object {
-                                    "key": "name",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "test model",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "version": Object {
-                                    "key": "version",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "v1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                },
-                                "valueCtor_": [Function],
-                              },
-                              "5": Object {
-                                "arrClean": true,
-                                "arr_": Array [
-                                  Array [
-                                    "__kf_run__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                  ],
-                                  Array [
-                                    "__kf_workspace__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                  ],
-                                ],
-                                "map_": Object {
-                                  "__kf_run__": Object {
-                                    "key": "__kf_run__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "__kf_workspace__": Object {
-                                    "key": "__kf_workspace__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "workspace-1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                },
-                                "valueCtor_": [Function],
-                              },
-                            },
-                          }
-                        }
-                        rightAffordance={true}
-                      >
-                        <div
-                          className="cardRow lastRow"
-                        >
-                          <div
-                            className="noRadio"
-                          />
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              test model
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              workspace-1
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeLeft"
-                            key="edgeLeft"
-                          />
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                    </div>
-                  </div>
-                </LineageCard>
-              </div>
-            </div>
-          </LineageCardColumn>
-          <LineageCardColumn
-            cards={
-              Array [
-                Object {
-                  "elements": Array [],
-                  "title": "Execution",
-                },
-              ]
-            }
-            title=""
-            type="execution"
-          >
-            <div
-              className="mainColumn execution"
-            >
-              <div
-                className="columnHeader"
-              >
-                <h2 />
-              </div>
-              <div
-                className="columnBody"
-              >
-                <EdgeCanvas
-                  cardArray={
-                    Array [
-                      0,
-                    ]
-                  }
-                  reverseEdges={false}
-                  type="execution"
-                >
-                  <div
-                    className="edgeCanvas"
-                  />
-                </EdgeCanvas>
-                <LineageCard
-                  addSpacer={false}
-                  isTarget={false}
-                  key="0"
-                  rows={Array []}
-                  title="Execution"
-                  type="execution"
-                >
-                  <div
-                    className="cardContainer execution"
-                  >
-                    <div
-                      className="cardTitle"
-                    >
-                      <h3>
-                        Execution
-                      </h3>
-                    </div>
-                    <div
-                      className="cardBody"
-                    />
-                  </div>
-                </LineageCard>
-              </div>
-            </div>
-          </LineageCardColumn>
-          <LineageCardColumn
-            cards={
-              Array [
-                Object {
-                  "elements": Array [
-                    Object {
-                      "next": true,
-                      "prev": true,
-                      "resource": Object {
-                        "array": Array [
-                          1,
-                          1,
-                          "gs://my-bucket/mnist",
-                          Array [
-                            Array [
-                              "__ALL_META__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                              ],
-                            ],
-                            Array [
-                              "create_time",
-                              Array [
-                                undefined,
-                                undefined,
-                                "2019-06-12T01:21:48.259263Z",
-                              ],
-                            ],
-                            Array [
-                              "description",
-                              Array [
-                                undefined,
-                                undefined,
-                                "A really great model",
-                              ],
-                            ],
-                            Array [
-                              "name",
-                              Array [
-                                undefined,
-                                undefined,
-                                "test model",
-                              ],
-                            ],
-                            Array [
-                              "version",
-                              Array [
-                                undefined,
-                                undefined,
-                                "v1",
-                              ],
-                            ],
-                          ],
-                          Array [
-                            Array [
-                              "__kf_run__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "1",
-                              ],
-                            ],
-                            Array [
-                              "__kf_workspace__",
-                              Array [
-                                undefined,
-                                undefined,
-                                "workspace-1",
-                              ],
-                            ],
-                          ],
-                        ],
-                        "arrayIndexOffset_": -1,
-                        "convertedPrimitiveFields_": Object {},
-                        "messageId_": undefined,
-                        "pivot_": 1.7976931348623157e+308,
-                        "wrappers_": Object {
-                          "4": Object {
-                            "arrClean": true,
-                            "arr_": Array [
-                              Array [
-                                "__ALL_META__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                              ],
-                              Array [
-                                "create_time",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                              ],
-                              Array [
-                                "description",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                              ],
-                              Array [
-                                "name",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                              ],
-                              Array [
-                                "version",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                              ],
-                            ],
-                            "map_": Object {
-                              "__ALL_META__": Object {
-                                "key": "__ALL_META__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "create_time": Object {
-                                "key": "create_time",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "description": Object {
-                                "key": "description",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "name": Object {
-                                "key": "name",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "version": Object {
-                                "key": "version",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                            },
-                            "valueCtor_": [Function],
-                          },
-                          "5": Object {
-                            "arrClean": true,
-                            "arr_": Array [
-                              Array [
-                                "__kf_run__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                              ],
-                              Array [
-                                "__kf_workspace__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                              ],
-                            ],
-                            "map_": Object {
-                              "__kf_run__": Object {
-                                "key": "__kf_run__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                              "__kf_workspace__": Object {
-                                "key": "__kf_workspace__",
-                                "value": Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                                "valueWrapper": Object {
-                                  "array": Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                  "arrayIndexOffset_": -1,
-                                  "convertedPrimitiveFields_": Object {},
-                                  "messageId_": undefined,
-                                  "pivot_": 1.7976931348623157e+308,
-                                  "wrappers_": null,
-                                },
-                              },
-                            },
-                            "valueCtor_": [Function],
-                          },
-                        },
-                      },
-                    },
-                  ],
-                  "title": "Artifact",
-                },
-              ]
-            }
-            reverseBindings={true}
-            setLineageViewTarget={[Function]}
-            title="Output Artifact"
-            type="artifact"
-          >
-            <div
-              className="mainColumn artifact"
-            >
-              <div
-                className="columnHeader"
-              >
-                <h2>
-                  Output Artifact
-                </h2>
-              </div>
-              <div
-                className="columnBody"
-              >
-                <EdgeCanvas
-                  cardArray={
-                    Array [
-                      1,
-                    ]
-                  }
-                  reverseEdges={true}
-                  type="artifact"
-                >
-                  <div
-                    className="edgeCanvas edgeCanvasReverse"
-                  >
-                    <LineChart
-                      areaVisible={false}
-                      axisColor="#34495e"
-                      axisOpacity={0.3}
-                      axisVisible={false}
-                      axisWidth={1}
-                      data={
-                        Array [
-                          Object {
-                            "x": 0,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 30,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 170,
-                            "y": 0,
-                          },
-                          Object {
-                            "x": 200,
-                            "y": 0,
-                          },
-                        ]
-                      }
-                      getX={[Function]}
-                      getY={[Function]}
-                      gridColor="#34495e"
-                      gridOpacity={0.2}
-                      gridVisible={false}
-                      gridWidth={1}
-                      key="0-0"
-                      labelsCharacterWidth={10}
-                      labelsColor="#bdc3c7"
-                      labelsCountY={5}
-                      labelsFormatX={[Function]}
-                      labelsFormatY={[Function]}
-                      labelsHeightX={12}
-                      labelsOffsetX={15}
-                      labelsOffsetY={15}
-                      labelsStepX={2}
-                      labelsVisible={false}
-                      pathColor="#BDC1C6"
-                      pathOpacity={1}
-                      pathSmoothing={0}
-                      pathVisible={true}
-                      pathWidth={1}
-                      pointsColor="#fff"
-                      pointsIsHoverOnZone={false}
-                      pointsOnHover={[Function]}
-                      pointsRadius={4}
-                      pointsStrokeColor="#34495e"
-                      pointsStrokeWidth={2}
-                      pointsVisible={false}
-                      viewBoxHeight={1}
-                      viewBoxWidth={200}
-                    >
-                      <styled.svg
-                        viewBox="0 0 200 1"
-                      >
-                        <svg
-                          className="sc-gzVnrw kWKfgJ"
-                          viewBox="0 0 200 1"
-                        >
-                          <g
-                            transform="translate(0, 0)"
-                          >
-                            <Grid
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Path
-                              areaColor="#34495e"
-                              areaOpacity={0.5}
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            >
-                              <g>
-                                <styled.path
-                                  color="#BDC1C6"
-                                  d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                  opacity={1}
-                                  width={1}
-                                >
-                                  <path
-                                    className="sc-htpNat emMQTt"
-                                    color="#BDC1C6"
-                                    d="M 0 1  C
-      0
-      1
-      0
-      1
-      5
-      1
-      C
-      10
-      1
-      20
-      1
-      48.33
-      1
-      C
-      76.67
-      1
-      123.33
-      1
-      151.67
-      1
-     C
-      180
-      1
-      190
-      1
-      195
-      1
-    L 200 1 "
-                                    opacity={1}
-                                    width={1}
-                                  />
-                                </styled.path>
-                              </g>
-                            </Path>
-                            <Axis
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Points
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                            <Labels
-                              areaVisible={false}
-                              axisColor="#34495e"
-                              axisOpacity={0.3}
-                              axisVisible={false}
-                              axisWidth={1}
-                              data={
-                                Array [
-                                  Object {
-                                    "x": 0,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 30,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 170,
-                                    "y": 0,
-                                  },
-                                  Object {
-                                    "x": 200,
-                                    "y": 0,
-                                  },
-                                ]
-                              }
-                              getX={[Function]}
-                              getY={[Function]}
-                              gridColor="#34495e"
-                              gridOpacity={0.2}
-                              gridVisible={false}
-                              gridWidth={1}
-                              labelsCharacterWidth={10}
-                              labelsColor="#bdc3c7"
-                              labelsCountY={5}
-                              labelsFormatX={[Function]}
-                              labelsFormatY={[Function]}
-                              labelsHeightX={12}
-                              labelsOffsetX={15}
-                              labelsOffsetY={15}
-                              labelsStepX={2}
-                              labelsVisible={false}
-                              maxX={200}
-                              maxY={5}
-                              minX={0}
-                              minY={0}
-                              pathColor="#BDC1C6"
-                              pathOpacity={1}
-                              pathSmoothing={0}
-                              pathVisible={true}
-                              pathWidth={1}
-                              pointsColor="#fff"
-                              pointsIsHoverOnZone={false}
-                              pointsOnHover={[Function]}
-                              pointsRadius={4}
-                              pointsStrokeColor="#34495e"
-                              pointsStrokeWidth={2}
-                              pointsVisible={false}
-                            />
-                          </g>
-                        </svg>
-                      </styled.svg>
-                    </LineChart>
-                  </div>
-                </EdgeCanvas>
-                <LineageCard
-                  addSpacer={false}
-                  isTarget={false}
-                  key="0"
-                  rows={
-                    Array [
-                      Object {
-                        "next": true,
-                        "prev": true,
-                        "resource": Object {
-                          "array": Array [
-                            1,
-                            1,
-                            "gs://my-bucket/mnist",
-                            Array [
-                              Array [
-                                "__ALL_META__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                ],
-                              ],
-                              Array [
-                                "create_time",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "2019-06-12T01:21:48.259263Z",
-                                ],
-                              ],
-                              Array [
-                                "description",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "A really great model",
-                                ],
-                              ],
-                              Array [
-                                "name",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "test model",
-                                ],
-                              ],
-                              Array [
-                                "version",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "v1",
-                                ],
-                              ],
-                            ],
-                            Array [
-                              Array [
-                                "__kf_run__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "1",
-                                ],
-                              ],
-                              Array [
-                                "__kf_workspace__",
-                                Array [
-                                  undefined,
-                                  undefined,
-                                  "workspace-1",
-                                ],
-                              ],
-                            ],
-                          ],
-                          "arrayIndexOffset_": -1,
-                          "convertedPrimitiveFields_": Object {},
-                          "messageId_": undefined,
-                          "pivot_": 1.7976931348623157e+308,
-                          "wrappers_": Object {
-                            "4": Object {
-                              "arrClean": true,
-                              "arr_": Array [
-                                Array [
-                                  "__ALL_META__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                ],
-                                Array [
-                                  "create_time",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                ],
-                                Array [
-                                  "description",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                ],
-                                Array [
-                                  "name",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                ],
-                                Array [
-                                  "version",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                ],
-                              ],
-                              "map_": Object {
-                                "__ALL_META__": Object {
-                                  "key": "__ALL_META__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "create_time": Object {
-                                  "key": "create_time",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "description": Object {
-                                  "key": "description",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "name": Object {
-                                  "key": "name",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "version": Object {
-                                  "key": "version",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                              },
-                              "valueCtor_": [Function],
-                            },
-                            "5": Object {
-                              "arrClean": true,
-                              "arr_": Array [
-                                Array [
-                                  "__kf_run__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                ],
-                                Array [
-                                  "__kf_workspace__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                ],
-                              ],
-                              "map_": Object {
-                                "__kf_run__": Object {
-                                  "key": "__kf_run__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                                "__kf_workspace__": Object {
-                                  "key": "__kf_workspace__",
-                                  "value": Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                  "valueWrapper": Object {
-                                    "array": Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                    "arrayIndexOffset_": -1,
-                                    "convertedPrimitiveFields_": Object {},
-                                    "messageId_": undefined,
-                                    "pivot_": 1.7976931348623157e+308,
-                                    "wrappers_": null,
-                                  },
-                                },
-                              },
-                              "valueCtor_": [Function],
-                            },
-                          },
-                        },
-                      },
-                    ]
-                  }
-                  setLineageViewTarget={[Function]}
-                  title="Artifact"
-                  type="artifact"
-                >
-                  <div
-                    className="cardContainer artifact"
-                  >
-                    <div
-                      className="cardTitle"
-                    >
-                      <h3>
-                        Artifact
-                      </h3>
-                    </div>
-                    <div
-                      className="cardBody"
-                    >
-                      <LineageCardRow
-                        hideRadio={false}
-                        isLastRow={true}
-                        key="0"
-                        leftAffordance={true}
-                        resource={
-                          Object {
-                            "array": Array [
-                              1,
-                              1,
-                              "gs://my-bucket/mnist",
-                              Array [
-                                Array [
-                                  "__ALL_META__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                  ],
-                                ],
-                                Array [
-                                  "create_time",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "2019-06-12T01:21:48.259263Z",
-                                  ],
-                                ],
-                                Array [
-                                  "description",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "A really great model",
-                                  ],
-                                ],
-                                Array [
-                                  "name",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "test model",
-                                  ],
-                                ],
-                                Array [
-                                  "version",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "v1",
-                                  ],
-                                ],
-                              ],
-                              Array [
-                                Array [
-                                  "__kf_run__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "1",
-                                  ],
-                                ],
-                                Array [
-                                  "__kf_workspace__",
-                                  Array [
-                                    undefined,
-                                    undefined,
-                                    "workspace-1",
-                                  ],
-                                ],
-                              ],
-                            ],
-                            "arrayIndexOffset_": -1,
-                            "convertedPrimitiveFields_": Object {},
-                            "messageId_": undefined,
-                            "pivot_": 1.7976931348623157e+308,
-                            "wrappers_": Object {
-                              "4": Object {
-                                "arrClean": true,
-                                "arr_": Array [
-                                  Array [
-                                    "__ALL_META__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                  ],
-                                  Array [
-                                    "create_time",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                  ],
-                                  Array [
-                                    "description",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                  ],
-                                  Array [
-                                    "name",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                  ],
-                                  Array [
-                                    "version",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                  ],
-                                ],
-                                "map_": Object {
-                                  "__ALL_META__": Object {
-                                    "key": "__ALL_META__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "{\\"hyperparameters\\": {\\"early_stop\\": true, \\"layers\\": [10, 3, 1], \\"learning_rate\\": 0.5}, \\"model_type\\": \\"neural network\\", \\"training_framework\\": {\\"name\\": \\"tensorflow\\", \\"version\\": \\"v1.0\\"}}",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "create_time": Object {
-                                    "key": "create_time",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "2019-06-12T01:21:48.259263Z",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "2019-06-12T01:21:48.259263Z",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "description": Object {
-                                    "key": "description",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "A really great model",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "A really great model",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "name": Object {
-                                    "key": "name",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "test model",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "test model",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "version": Object {
-                                    "key": "version",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "v1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "v1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                },
-                                "valueCtor_": [Function],
-                              },
-                              "5": Object {
-                                "arrClean": true,
-                                "arr_": Array [
-                                  Array [
-                                    "__kf_run__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                  ],
-                                  Array [
-                                    "__kf_workspace__",
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                  ],
-                                ],
-                                "map_": Object {
-                                  "__kf_run__": Object {
-                                    "key": "__kf_run__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                  "__kf_workspace__": Object {
-                                    "key": "__kf_workspace__",
-                                    "value": Array [
-                                      undefined,
-                                      undefined,
-                                      "workspace-1",
-                                    ],
-                                    "valueWrapper": Object {
-                                      "array": Array [
-                                        undefined,
-                                        undefined,
-                                        "workspace-1",
-                                      ],
-                                      "arrayIndexOffset_": -1,
-                                      "convertedPrimitiveFields_": Object {},
-                                      "messageId_": undefined,
-                                      "pivot_": 1.7976931348623157e+308,
-                                      "wrappers_": null,
-                                    },
-                                  },
-                                },
-                                "valueCtor_": [Function],
-                              },
-                            },
-                          }
-                        }
-                        rightAffordance={true}
-                        setLineageViewTarget={[Function]}
-                      >
-                        <div
-                          className="cardRow lastRow"
-                        >
-                          <div>
-                            <input
-                              className="form-radio"
-                              name=""
-                              onClick={[Function]}
-                              type="radio"
-                              value=""
-                            />
-                          </div>
-                          <footer>
-                            <p
-                              className="rowTitle"
-                            >
-                              test model
-                            </p>
-                            <p
-                              className="rowDesc"
-                            >
-                              workspace-1
-                            </p>
-                          </footer>
-                          <div
-                            className="edgeLeft"
-                            key="edgeLeft"
-                          />
-                          <div
-                            className="edgeRight"
-                            key="edgeRight"
-                          />
-                        </div>
-                      </LineageCardRow>
-                    </div>
-                  </div>
-                </LineageCard>
-              </div>
-            </div>
-          </LineageCardColumn>
-        </div>
-      </div>
-    </LineageView>
+          </dl>
+        </section>
+      </ResourceInfo>
+    </div>
   </div>
 </ArtifactDetails>
 `;


### PR DESCRIPTION
## Implementation

* Adds RPCs to fetch Input and Output executions for the target artifact
* Adds RPCs to fetch Input and Output artifacts for the input and output executions
* Pass down real Artifact and Execution objects to LineageCardRow and pass them up when an artifact is clicked. 
* Partial implementation of  #150 and #152

## Demo

* https://screencast.googleplex.com/cast/NDgxMjQzNDIyNzMzMTA3MnwwZjVjMDM2My00MQ
* https://kubeflow-ui-07.endpoints.kwasinti-kubeflow-dev.cloud.goog/_/metadata/#/artifact_types/kubeflow.org/alpha/data_set/artifacts/3

## Notes

* This is a pretty barebones PR providing just enough to get the RPC calls hooked up. 
* All RPCs are executed serially.
* There is no empty state
* There is no spinner when loading data
* Has not been tested with a large data set with multiple executions or deep lineage history

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/179)
<!-- Reviewable:end -->
