### PR TITLE
[Windows] Changes to allow docker building on windows

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /frontend
 
 COPY . .
 
-RUN npm install && \
+RUN npm install && npm rebuild node-sass && \
   npm run postinstall && \
   CI=true npm run test:coverage && \
   npm run build

--- a/frontend/docker_build.js
+++ b/frontend/docker_build.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const {exec, spawn} = require('child_process')
+const runCmd = cmd => new Promise((res, rej) => exec(cmd, (e, out, err) => e?rej(e):res({out, err})))
+
+// COMMIT_HASH=`git rev-parse HEAD`; docker build -t gcr.io/kubeflow-images-public/metadata-frontend:${COMMIT_HASH} --build-arg COMMIT_HASH=${COMMIT_HASH} --build-arg DATE=\"`date -u`\" .
+const main = async _ => {
+    const commitHash = (await runCmd('git rev-parse HEAD')).out.trim()
+    const date = new Date().toUTCString()
+    const protocProcess = spawn(
+        'docker', [
+            `build`,
+            `-t`,`gcr.io/kubeflow-images-public/metadata-frontend:${commitHash}`,
+            `--build-arg`,`COMMIT_HASH=${commitHash}`,
+            `--build-arg`,`DATE="${date}"`,
+            `.`
+        ], {shell: true}
+    );
+    protocProcess.stdout.on('data', buffer => console.log(buffer.toString()))
+    protocProcess.stderr.on('data', buffer => console.error(buffer.toString()))
+    protocProcess.on('close', code => {
+        if (code) return
+        console.log(`Docker image built!`)
+    })
+}
+
+main()

--- a/frontend/docker_build.js
+++ b/frontend/docker_build.js
@@ -1,5 +1,10 @@
-const fs = require('fs');
-const path = require('path');
+/**
+ * Docker build cross platform script for KF Metadata
+ * This will calculate your current hash, and build date and use them
+ * to build the docker image in the format:
+ * 
+ * gcr.io/kubeflow-images-public/metadata-frontend:${COMMIT_HASH}
+ */
 const {exec, spawn} = require('child_process')
 const runCmd = cmd => new Promise((res, rej) => exec(cmd, (e, out, err) => e?rej(e):res({out, err})))
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "apis:metadata": "node ./gen_grpc_web_protos.js",
     "apis:service": "java -jar swagger-codegen-cli.jar generate -i ../api/service.swagger.json -l typescript-fetch -o ./src/apis/service -c ./swagger-config.json",
     "build": "cross-env EXTEND_ESLINT=true react-scripts build",
-    "docker": "cross-env COMMIT_HASH=`git rev-parse HEAD`; docker build -t gcr.io/kubeflow-images-public/metadata-frontend:${COMMIT_HASH} --build-arg COMMIT_HASH=${COMMIT_HASH} --build-arg DATE=\"`date -u`\" .",
+    "docker": "node ./docker_build.js",
     "eject": "cross-env EXTEND_ESLINT=true react-scripts eject",
     "postinstall": "cd ./server && npm i",
     "start": "cross-env EXTEND_ESLINT=true react-scripts start",


### PR DESCRIPTION
## About
- `npm run docker` now runs a new script called `./docker_build.js` which will create the docker images cross-platform
- The docker build script does handle dates slightly differently: (instead of using `date -u` we now use js' `new Date().toUTCString()`)
  - No double space between month and date
  - An extra comma is removed after the date
  - UTC uses 24h clock instead of 12hr with AM / PM

**Release note**:
```release-note
Windows support for building node images, cross-platform node scripts
```

### Meta
/area metadata
/area front-end
/priority p1
/assign @avdaredevil
/cc @kwasi 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/180)
<!-- Reviewable:end -->
