### PR TITLE
Move LineageView key sizes to LineageView props

### DIFF
--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -374,5 +374,3 @@ export function _paddingInternal(units?: number, directions?: string): NestedCSS
 export function padding(units?: number, directions?: string): string {
   return style(_paddingInternal(units, directions));
 }
-
-export const px = (number: number): string => `${number}px`;

--- a/frontend/src/components/EdgeCanvas.tsx
+++ b/frontend/src/components/EdgeCanvas.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
 import LineChart from 'react-svg-line-chart';
 import {classes, stylesheet} from 'typestyle';
+import {px} from './LineageCss';
 import {LineageCardType} from './LineageTypes';
 import './LineChart.d.ts';
-import {px} from '../Css';
-import {CARD_WIDTH, EDGE_WIDTH} from "./LineageCss";
 
 interface EdgeCanvasProps {
   cardArray: number[];
   reverseEdges: boolean;
   type: LineageCardType;
+  cardWidth: number;
+  edgeWidth: number;
 }
 
-export const EdgeCanvas: React.FC<EdgeCanvasProps> = ({cardArray, reverseEdges}) => {
+export const EdgeCanvas: React.FC<EdgeCanvasProps> = ({cardArray, cardWidth, edgeWidth, reverseEdges}) => {
   let viewHeight = 1;
 
   const cardBodyHeight = 67;
@@ -26,11 +27,11 @@ export const EdgeCanvas: React.FC<EdgeCanvasProps> = ({cardArray, reverseEdges})
       border: 0,
       display: 'block',
       height: px(440),
-      marginLeft: px(CARD_WIDTH),
+      marginLeft: px(cardWidth),
       marginTop: px(74),
       overflow: 'visible',
       position: 'absolute',
-      width: EDGE_WIDTH,
+      width: edgeWidth,
       zIndex: -1,
       '$nest': {
         svg: {
@@ -62,8 +63,8 @@ export const EdgeCanvas: React.FC<EdgeCanvasProps> = ({cardArray, reverseEdges})
           data={[
             {x: 0, y: y1},
             {x: 30, y: y1},
-            {x: EDGE_WIDTH - 30, y: y4},
-            {x: EDGE_WIDTH, y: y4},
+            {x: edgeWidth - 30, y: y4},
+            {x: edgeWidth, y: y4},
           ]}
           areaVisible={false}
           axisVisible={false}
@@ -75,7 +76,7 @@ export const EdgeCanvas: React.FC<EdgeCanvasProps> = ({cardArray, reverseEdges})
           pathOpacity={1}
           pointsVisible={false}
           viewBoxHeight={viewHeight}
-          viewBoxWidth={EDGE_WIDTH}
+          viewBoxWidth={edgeWidth}
           pathSmoothing={0}
         />
       );

--- a/frontend/src/components/LineageCard.tsx
+++ b/frontend/src/components/LineageCard.tsx
@@ -1,12 +1,11 @@
-import * as React from 'react';
 import {blue, grey} from '@material-ui/core/colors';
+import * as React from 'react';
+import {classes, stylesheet} from 'typestyle';
+import {CSSProperties} from 'typestyle/lib/types';
 import {LineageCardRow} from './LineageCardRow';
 import {LineageRow, LineageCardType} from './LineageTypes';
-import {Artifact} from "../generated/src/apis/metadata/metadata_store_pb";
-import {classes, stylesheet} from "typestyle";
-import {px} from '../Css';
-import {CSSProperties} from "typestyle/lib/types";
-import {CARD_WIDTH} from "./LineageCss";
+import {Artifact} from '../generated/src/apis/metadata/metadata_store_pb';
+import {px} from './LineageCss';
 
 const CARD_RADIUS = 6;
 
@@ -16,47 +15,8 @@ const cardTitleBase: CSSProperties = {
   height: '40px',
 };
 
-const css = stylesheet({
-  addSpacer: {
-    marginTop: '24px',
-  },
-  cardContainer: {
-    background: 'white',
-    border: `1px solid ${grey[300]}`,
-    borderRadius: px(CARD_RADIUS),
-    width: px(CARD_WIDTH),
-    $nest: {
-      h3: {
-        color: blue[600],
-        fontFamily: 'PublicSans-Medium',
-        fontSize: '10px',
-        letterSpacing: '0.8px',
-        lineHeight: '42px',
-        paddingLeft: '20px',
-        textAlign: 'left',
-        textTransform: 'uppercase',
-      }
-    }
-  },
-  cardTitle: {
-    ...cardTitleBase,
-    borderBottom: `1px solid ${grey[200]}`,
-  },
-  execution: {
-    borderRadius: px(CARD_RADIUS),
-    background: '#F8FBFF',
-    border: '1px solid #CCE4FF',
-  },
-  executionCardTitle: {
-    ...cardTitleBase,
-    borderBottom: '1px solid transparent',
-  },
-  target: {
-    border: `2px solid ${blue[500]}`,
-  }
-});
-
 interface LineageCardProps {
+  cardWidth: number,
   title: string;
   type: LineageCardType;
   rows: LineageRow[];
@@ -67,8 +27,48 @@ interface LineageCardProps {
 
 export class LineageCard extends React.Component<LineageCardProps> {
   public render(): JSX.Element {
-    const {title, type, rows, addSpacer, isTarget, setLineageViewTarget} = this.props;
+    const {cardWidth, title, type, rows, addSpacer, isTarget, setLineageViewTarget} = this.props;
     const isExecution = type === 'execution';
+
+    const css = stylesheet({
+      addSpacer: {
+        marginTop: '24px',
+      },
+      cardContainer: {
+        background: 'white',
+        border: `1px solid ${grey[300]}`,
+        borderRadius: px(CARD_RADIUS),
+        width: px(cardWidth),
+        $nest: {
+          h3: {
+            color: blue[600],
+            fontFamily: 'PublicSans-Medium',
+            fontSize: '10px',
+            letterSpacing: '0.8px',
+            lineHeight: '42px',
+            paddingLeft: '20px',
+            textAlign: 'left',
+            textTransform: 'uppercase',
+          }
+        }
+      },
+      cardTitle: {
+        ...cardTitleBase,
+        borderBottom: `1px solid ${grey[200]}`,
+      },
+      execution: {
+        borderRadius: px(CARD_RADIUS),
+        background: '#F8FBFF',
+        border: '1px solid #CCE4FF',
+      },
+      executionCardTitle: {
+        ...cardTitleBase,
+        borderBottom: '1px solid transparent',
+      },
+      target: {
+        border: `2px solid ${blue[500]}`,
+      }
+    });
 
     const listCardRows = () => rows.map((r, i) =>
       <LineageCardRow

--- a/frontend/src/components/LineageCardColumn.tsx
+++ b/frontend/src/components/LineageCardColumn.tsx
@@ -1,42 +1,11 @@
+import grey from '@material-ui/core/colors/grey';
 import React from 'react';
 import {classes, stylesheet} from 'typestyle';
-import {px} from '../Css';
 import {Artifact} from '../generated/src/apis/metadata/metadata_store_pb';
 import {LineageCard} from './LineageCard';
+import {px} from './LineageCss';
 import {LineageCardType, LineageRow} from './LineageTypes';
 import {EdgeCanvas} from './EdgeCanvas';
-import grey from '@material-ui/core/colors/grey';
-import {CARD_WIDTH, EDGE_WIDTH} from './LineageCss';
-
-const css = stylesheet({
-  mainColumn: {
-    display: 'inline-block',
-    justifyContent: 'center',
-    minHeight: '100%',
-    padding: `0 ${EDGE_WIDTH  / 2}px`,
-    width: px(CARD_WIDTH),
-    $nest: {
-      h2: {
-        color: grey[600],
-        fontFamily: 'PublicSans-Regular',
-        fontSize: '12px',
-        letterSpacing: '0.5px',
-        lineHeight: '40px',
-        textAlign: 'left',
-        textTransform: 'capitalize'
-      }
-    }
-  },
-  columnBody: {
-    width: px(CARD_WIDTH),
-  },
-  columnHeader: {
-    height: '40px',
-    margin: '10px 0px',
-    textAlign: 'left',
-    width: px(CARD_WIDTH),
-  }
-});
 
 // Todo: Replace this with the actual interface / class used by the APIs
 export interface CardDetails {
@@ -48,13 +17,45 @@ export interface LineageCardColumnProps {
   type: LineageCardType;
   title: string;
   cards: CardDetails[];
+  cardWidth: number;
+  edgeWidth: number;
   reverseBindings?: boolean;
   setLineageViewTarget?(artifact: Artifact): void
 }
 
 export class LineageCardColumn extends React.Component<LineageCardColumnProps> {
   public render(): JSX.Element | null {
-    const {type, title} = this.props;
+    const {cardWidth, edgeWidth, type, title} = this.props;
+
+    const css = stylesheet({
+      mainColumn: {
+        display: 'inline-block',
+        justifyContent: 'center',
+        minHeight: '100%',
+        padding: `0 ${edgeWidth  / 2}px`,
+        width: px(cardWidth),
+        $nest: {
+          h2: {
+            color: grey[600],
+            fontFamily: 'PublicSans-Regular',
+            fontSize: '12px',
+            letterSpacing: '0.5px',
+            lineHeight: '40px',
+            textAlign: 'left',
+            textTransform: 'capitalize'
+          }
+        }
+      },
+      columnBody: {
+        width: px(cardWidth),
+      },
+      columnHeader: {
+        height: '40px',
+        margin: '10px 0px',
+        textAlign: 'left',
+        width: px(cardWidth),
+      }
+    });
 
     return (
       <div className={classes(css.mainColumn, type)}>
@@ -71,6 +72,7 @@ export class LineageCardColumn extends React.Component<LineageCardColumnProps> {
     const isNotFirstEl = i > 0;
     return <LineageCard
       key={i}
+      cardWidth={this.props.cardWidth}
       title={det.title}
       type={this.props.type}
       addSpacer={isNotFirstEl}
@@ -80,13 +82,15 @@ export class LineageCardColumn extends React.Component<LineageCardColumnProps> {
     />;
   }
   private drawColumnContent(): JSX.Element {
-    const {type, cards} = this.props;
+    const {type, cards, cardWidth, edgeWidth} = this.props;
     const cardSkeleton = cards.map(c => c.elements.length);
 
     return <React.Fragment>
       <EdgeCanvas
         type={type}
         cardArray={cardSkeleton}
+        cardWidth={cardWidth}
+        edgeWidth={edgeWidth}
         reverseEdges={!!this.props.reverseBindings} />
       {cards.map(this.jsxFromCardDetails.bind(this))}
     </React.Fragment>;

--- a/frontend/src/components/LineageCss.ts
+++ b/frontend/src/components/LineageCss.ts
@@ -1,2 +1,1 @@
-export const CARD_WIDTH = 260;
-export const EDGE_WIDTH = 120;
+export const px = (number: number): string => `${number}px`;

--- a/frontend/src/pages/ArtifactDetails.tsx
+++ b/frontend/src/pages/ArtifactDetails.tsx
@@ -29,6 +29,10 @@ import {GetArtifactsByIDRequest} from '../generated/src/apis/metadata/metadata_s
 import {Artifact} from '../generated/src/apis/metadata/metadata_store_pb';
 import LineageView from './LineageView';
 
+// Sizing constants for the LineageView
+const CARD_WIDTH = 260;
+const EDGE_WIDTH = 120;
+
 export enum ArtifactDetailsTab {
   OVERVIEW = 0,
   LINEAGE_EXPLORER = 1,
@@ -93,7 +97,11 @@ export default class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
           </div>
         )}
         {this.state.selectedTab === ArtifactDetailsTab.LINEAGE_EXPLORER && (
-            <LineageView target={this.state.artifact}/>
+            <LineageView
+              cardWidth={CARD_WIDTH}
+              edgeWidth={EDGE_WIDTH}
+              target={this.state.artifact}
+            />
         )}
       </div>
     );

--- a/frontend/src/pages/ArtifactDetails.tsx
+++ b/frontend/src/pages/ArtifactDetails.tsx
@@ -29,10 +29,6 @@ import {GetArtifactsByIDRequest} from '../generated/src/apis/metadata/metadata_s
 import {Artifact} from '../generated/src/apis/metadata/metadata_store_pb';
 import LineageView from './LineageView';
 
-// Sizing constants for the LineageView
-const CARD_WIDTH = 260;
-const EDGE_WIDTH = 120;
-
 export enum ArtifactDetailsTab {
   OVERVIEW = 0,
   LINEAGE_EXPLORER = 1,
@@ -97,11 +93,7 @@ export default class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
           </div>
         )}
         {this.state.selectedTab === ArtifactDetailsTab.LINEAGE_EXPLORER && (
-            <LineageView
-              cardWidth={CARD_WIDTH}
-              edgeWidth={EDGE_WIDTH}
-              target={this.state.artifact}
-            />
+            <LineageView target={this.state.artifact} />
         )}
       </div>
     );

--- a/frontend/src/pages/LineageView.tsx
+++ b/frontend/src/pages/LineageView.tsx
@@ -39,6 +39,8 @@ const isOutputEvent = (event: Event) =>
   [Event.Type.OUTPUT.valueOf(), Event.Type.DECLARED_OUTPUT.valueOf()].includes(event.getType());
 
 export interface LineageViewProps {
+  cardWidth: number;
+  edgeWidth: number;
   target: Artifact;
 }
 
@@ -77,6 +79,7 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
 
   public render(): JSX.Element {
     const {columnNames} = this.state;
+    const {cardWidth, edgeWidth} = this.props;
     return (
       <div className={classes(commonCss.page)}>
         <LineageActionBar ref={this.actionBarRef} initialTarget={this.props.target} setLineageViewTarget={this.setTargetFromActionBar} />
@@ -85,24 +88,34 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
             type='artifact'
             cards={this.buildArtifactCards(this.state.inputArtifacts)}
             title={`${columnNames[0]}`}
+            cardWidth={cardWidth}
+            edgeWidth={edgeWidth}
             setLineageViewTarget={this.setTargetFromLineageCard}
           />
           <LineageCardColumn
             type='execution'
             cards={this.buildExecutionCards(this.state.inputExecutions)}
+            cardWidth={cardWidth}
+            edgeWidth={edgeWidth}
             title={`${columnNames[1]}`} />
           <LineageCardColumn
             type='artifact'
             cards={this.buildArtifactCards([this.state.target])}
+            cardWidth={cardWidth}
+            edgeWidth={edgeWidth}
             title={`${columnNames[2]}`} />
           <LineageCardColumn
             type='execution'
             cards={this.buildExecutionCards(this.state.outputExecutions)}
+            cardWidth={cardWidth}
+            edgeWidth={edgeWidth}
             title={`${columnNames[3]}`} />
           <LineageCardColumn
             type='artifact'
             cards={this.buildArtifactCards(this.state.outputArtifacts)}
             reverseBindings={true}
+            cardWidth={cardWidth}
+            edgeWidth={edgeWidth}
             title={`${columnNames[4]}`}
             setLineageViewTarget={this.setTargetFromLineageCard}
           />

--- a/frontend/src/pages/LineageView.tsx
+++ b/frontend/src/pages/LineageView.tsx
@@ -31,17 +31,23 @@ import {
 } from '../generated/src/apis/metadata/metadata_store_service_pb';
 import {
   MetadataStoreServicePromiseClient
-} from "../generated/src/apis/metadata/metadata_store_service_grpc_web_pb";
+} from '../generated/src/apis/metadata/metadata_store_service_grpc_web_pb';
 
 const isInputEvent = (event: Event) =>
   [Event.Type.INPUT.valueOf(), Event.Type.DECLARED_INPUT.valueOf()].includes(event.getType());
 const isOutputEvent = (event: Event) =>
   [Event.Type.OUTPUT.valueOf(), Event.Type.DECLARED_OUTPUT.valueOf()].includes(event.getType());
 
+/** Default size used when cardWidth prop is unset. */
+const DEFAULT_CARD_WIDTH = 260;
+
+/** Default size used when edgeWidth prop is unset. */
+const DEFAULT_EDGE_WIDTH = 120;
+
 export interface LineageViewProps {
-  cardWidth: number;
-  edgeWidth: number;
   target: Artifact;
+  cardWidth?: number;
+  edgeWidth?: number;
 }
 
 interface LineageViewState {
@@ -79,7 +85,8 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
 
   public render(): JSX.Element {
     const {columnNames} = this.state;
-    const {cardWidth, edgeWidth} = this.props;
+    const cardWidth = this.props.cardWidth || DEFAULT_CARD_WIDTH;
+    const edgeWidth = this.props.edgeWidth || DEFAULT_EDGE_WIDTH;
     return (
       <div className={classes(commonCss.page)}>
         <LineageActionBar ref={this.actionBarRef} initialTarget={this.props.target} setLineageViewTarget={this.setTargetFromActionBar} />

--- a/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
@@ -392,8 +392,6 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
       </MD2Tabs>
     </div>
     <LineageView
-      cardWidth={260}
-      edgeWidth={120}
       target={
         Object {
           "array": Array [

--- a/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ArtifactDetails.test.tsx.snap
@@ -392,6 +392,8 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
       </MD2Tabs>
     </div>
     <LineageView
+      cardWidth={260}
+      edgeWidth={120}
       target={
         Object {
           "array": Array [
@@ -1188,6 +1190,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
           }
         >
           <LineageCardColumn
+            cardWidth={260}
             cards={
               Array [
                 Object {
@@ -1486,6 +1489,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 },
               ]
             }
+            edgeWidth={120}
             setLineageViewTarget={[Function]}
             title="Input Artifact"
             type="artifact"
@@ -1509,6 +1513,8 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       1,
                     ]
                   }
+                  cardWidth={260}
+                  edgeWidth={120}
                   reverseEdges={false}
                   type="artifact"
                 >
@@ -1961,6 +1967,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 </EdgeCanvas>
                 <LineageCard
                   addSpacer={false}
+                  cardWidth={260}
                   isTarget={false}
                   key="0"
                   rows={
@@ -2609,6 +2616,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
             </div>
           </LineageCardColumn>
           <LineageCardColumn
+            cardWidth={260}
             cards={
               Array [
                 Object {
@@ -2617,6 +2625,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 },
               ]
             }
+            edgeWidth={120}
             title=""
             type="execution"
           >
@@ -2637,6 +2646,8 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       0,
                     ]
                   }
+                  cardWidth={260}
+                  edgeWidth={120}
                   reverseEdges={false}
                   type="execution"
                 >
@@ -2646,6 +2657,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 </EdgeCanvas>
                 <LineageCard
                   addSpacer={false}
+                  cardWidth={260}
                   isTarget={false}
                   key="0"
                   rows={Array []}
@@ -2671,6 +2683,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
             </div>
           </LineageCardColumn>
           <LineageCardColumn
+            cardWidth={260}
             cards={
               Array [
                 Object {
@@ -2969,6 +2982,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 },
               ]
             }
+            edgeWidth={120}
             title="Target"
             type="artifact"
           >
@@ -2991,6 +3005,8 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       1,
                     ]
                   }
+                  cardWidth={260}
+                  edgeWidth={120}
                   reverseEdges={false}
                   type="artifact"
                 >
@@ -3443,6 +3459,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 </EdgeCanvas>
                 <LineageCard
                   addSpacer={false}
+                  cardWidth={260}
                   isTarget={true}
                   key="0"
                   rows={
@@ -4083,6 +4100,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
             </div>
           </LineageCardColumn>
           <LineageCardColumn
+            cardWidth={260}
             cards={
               Array [
                 Object {
@@ -4091,6 +4109,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 },
               ]
             }
+            edgeWidth={120}
             title=""
             type="execution"
           >
@@ -4111,6 +4130,8 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       0,
                     ]
                   }
+                  cardWidth={260}
+                  edgeWidth={120}
                   reverseEdges={false}
                   type="execution"
                 >
@@ -4120,6 +4141,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 </EdgeCanvas>
                 <LineageCard
                   addSpacer={false}
+                  cardWidth={260}
                   isTarget={false}
                   key="0"
                   rows={Array []}
@@ -4145,6 +4167,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
             </div>
           </LineageCardColumn>
           <LineageCardColumn
+            cardWidth={260}
             cards={
               Array [
                 Object {
@@ -4443,6 +4466,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 },
               ]
             }
+            edgeWidth={120}
             reverseBindings={true}
             setLineageViewTarget={[Function]}
             title="Output Artifact"
@@ -4467,6 +4491,8 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                       1,
                     ]
                   }
+                  cardWidth={260}
+                  edgeWidth={120}
                   reverseEdges={true}
                   type="artifact"
                 >
@@ -4919,6 +4945,7 @@ exports[`ArtifactDetails Renders the Lineage Explorer tab for an artifact 1`] = 
                 </EdgeCanvas>
                 <LineageCard
                   addSpacer={false}
+                  cardWidth={260}
                   isTarget={false}
                   key="0"
                   rows={


### PR DESCRIPTION
/area front-end
/area metadata
/assign @avdaredevil 

This is a followup change to #183 to make it easier to migrate `LineageView` to a standalone repo.  I'm working under the assumption that any file named `Lineage*.tsx?` will be moved to the Lineage module of the shared-components repo.

## Changes

* Moves px() helper function out of `Css.tsx` into `LineageCss.ts` to eliminate a non-lineage dependency.
* Make `cardWidth` and `edgeWidth` props that are passed to LineageView and propagated down to `LineageCard` and `EdgeCanvas` 
* Make current key sizes (cardWidth=260px, edgeWidth=120) default parameters that can be overridden by props passed to `<LineageView />`. The goal is to allow `<ArtifactDetails />` the page/application to drive the sizes of the shared component `<LineageView />` while providing reasonable defaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/185)
<!-- Reviewable:end -->
