### PR TITLE
Change ubuntu python3.6 PPA

### DIFF
--- a/test/scripts/setup-services-run-tests.sh
+++ b/test/scripts/setup-services-run-tests.sh
@@ -40,7 +40,7 @@ echo "PROJECT: ${GCP_PROJECT}"
 
 apt-get update
 apt-get -y install software-properties-common python-software-properties
-add-apt-repository ppa:jonathonf/python-3.6
+add-apt-repository ppa:deadsnakes/ppa
 apt-get update
 apt-get -y install python3.6
 


### PR DESCRIPTION
The old way to install python3.6 for SDK testing is broken. Add this new PPA source to fix presubmit tests.

/cc @avdaredevil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/187)
<!-- Reviewable:end -->
