### PR TITLE
[MLMD Lineage] Execution Grouping Support added for Lineage View

### DIFF
--- a/frontend/src/components/LineageApi.ts
+++ b/frontend/src/components/LineageApi.ts
@@ -1,8 +1,9 @@
-import {ArtifactType} from "../generated/src/apis/metadata/metadata_store_pb";
-import {GetArtifactTypesRequest} from "../generated/src/apis/metadata/metadata_store_service_pb";
+import {ArtifactType, ExecutionType} from "../generated/src/apis/metadata/metadata_store_pb";
+import {GetArtifactTypesRequest, GetExecutionTypesRequest} from "../generated/src/apis/metadata/metadata_store_service_pb";
 import {MetadataStoreServicePromiseClient} from "../generated/src/apis/metadata/metadata_store_service_grpc_web_pb";
 
 export type ArtifactTypeMap = Map<number, ArtifactType>;
+export type ExecutionTypeMap = Map<number, ExecutionType>;
 
 export async function getArtifactTypes(
   metadataStoreService: MetadataStoreServicePromiseClient,
@@ -25,4 +26,27 @@ export async function getArtifactTypes(
   });
 
   return artifactTypesMap;
+}
+
+export async function getExecutionTypes(
+  metadataStoreService: MetadataStoreServicePromiseClient,
+  errorCallback?: (message: string) => void
+): Promise<ExecutionTypeMap> {
+  const response =
+    await metadataStoreService.getExecutionTypes(new GetExecutionTypesRequest());
+
+  if (!response) {
+    if (errorCallback) {
+      errorCallback('Unable to retrieve Execution Types, some features may not work.');
+    }
+    return new Map();
+  }
+
+  const executionTypesMap = new Map<number, ExecutionType>();
+
+  (response!.getExecutionTypesList() || []).forEach((executionType: ExecutionType) => {
+    executionTypesMap.set(executionType.getId()!, executionType);
+  });
+
+  return executionTypesMap;
 }

--- a/frontend/src/components/LineageCard.tsx
+++ b/frontend/src/components/LineageCard.tsx
@@ -19,7 +19,7 @@ const cardTitleBase: CSSProperties = {
 };
 
 interface LineageCardProps {
-  cardWidth: number,
+  cardWidth: number;
   title: string;
   type: LineageCardType;
   rows: LineageRow[];

--- a/frontend/src/components/LineageCardColumn.tsx
+++ b/frontend/src/components/LineageCardColumn.tsx
@@ -20,7 +20,7 @@ export interface LineageCardColumnProps {
   edgeWidth: number;
   reverseBindings?: boolean;
   skipEdgeCanvas?: boolean;
-  setLineageViewTarget?(artifact: Artifact): void
+  setLineageViewTarget?(artifact: Artifact): void;
 }
 
 export class LineageCardColumn extends React.Component<LineageCardColumnProps> {

--- a/frontend/src/pages/LineageView.tsx
+++ b/frontend/src/pages/LineageView.tsx
@@ -181,16 +181,6 @@ class LineageView extends React.Component<LineageViewProps, LineageViewState> {
         )
       };
     });
-    // return executions.map((execution) => ({
-    //   title: 'Execution',
-    //   elements: [
-    //     {
-    //       resource: execution,
-    //       prev: true,
-    //       next: true,
-    //     }
-    //   ]
-    // }))
   }
 
   private async loadData(targetId: number): Promise<string> {


### PR DESCRIPTION
**_fixes #196_**

## About
This change removes the static Execution column handler with the dynamic types supported within Kubeflow (and groups by type). Feature changes:
- Scan for Execution Types
- Create a map between Execution type name and id
- Group by Execution Type
- Reverse build edges from Output Execs to Target
- Linting warnings resolved
- Code nits

## Image
Grouped Execution Column with reverse edges | 
--- | 
![image](https://user-images.githubusercontent.com/5303018/71807029-9b903b00-3027-11ea-84f8-aa274dde6214.png) | 


### Meta
/area metadata
/area front-end
/priority p1
/assign @avdaredevil
/cc @kwasi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/200)
<!-- Reviewable:end -->
