### PR TITLE
Bump MLMD Python library so as to match Kubeflow 1.0rc

### DIFF
--- a/sdk/python/kubeflow/metadata/metadata.py
+++ b/sdk/python/kubeflow/metadata/metadata.py
@@ -86,8 +86,7 @@ class Store(object):
     if certificate_chain:
       config.ssl_config.server_cert = certificate_chain
 
-    self.store = metadata_store.MetadataStore(config,
-                                              disable_upgrade_migration=False)
+    self.store = metadata_store.MetadataStore(config)
 
 
 class Workspace(object):

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -15,10 +15,10 @@
 from setuptools import setup, find_packages
 
 NAME = 'kubeflow-metadata'
-VERSION = '0.3.0'
+VERSION = '0.3.1'
 
 REQUIRES = [
-    'ml-metadata==0.15.0',
+    'ml-metadata==0.21.1',
     'retrying'
 ]
 

--- a/sdk/python/tests/test_metadata.py
+++ b/sdk/python/tests/test_metadata.py
@@ -201,24 +201,6 @@ class TestMetedata(unittest.TestCase):
     with pytest.raises(ValueError, match=r".*exists with id.*"):
       metadata.Workspace(store, ws_name, reuse_workspace_if_exists=False)
 
-  def test_init_store_with_ssl_config(self):
-    # TODO: There is a type error in underlying ml_metadate library:
-    #   TypeError: expected certificate to be bytes, got <class 'str'>
-    # Fix this unit test once this bug is fixed.
-    with self.assertRaises(TypeError):
-      metadata.Store(grpc_host=GRPC_HOST,
-                     grpc_port=GRPC_PORT,
-                     root_certificates=b"cert",
-                     private_key=b"private_key",
-                     certificate_chain=b"chain")
-    with patch('ml_metadata.metadata_store.metadata_store.MetadataStore',
-               new=CheckMetadataStore) as m:
-      metadata.Store(grpc_host=GRPC_HOST,
-                     grpc_port=GRPC_PORT,
-                     root_certificates=b"cert",
-                     private_key=b"private_key",
-                     certificate_chain=b"chain")
-
   def test_artifact_deduplication(self):
     store = metadata.Store(grpc_host=GRPC_HOST, grpc_port=GRPC_PORT)
     ws1 = metadata.Workspace(store=store, name="workspace_one")
@@ -259,16 +241,6 @@ class TestMetedata(unittest.TestCase):
       self.assertFalse(cls.is_duplicated(m, m5))
       m6 = mlpb_artifact(2, "gcs://123", "ws1", "name1", "v1")
       self.assertFalse(cls.is_duplicated(m, m6))
-
-
-class CheckMetadataStore(object):
-
-  def __init__(self, config, disable_upgrade_migration=None):
-    assert disable_upgrade_migration is not None
-    assert config.ssl_config is not None
-    assert config.ssl_config.custom_ca is not None
-    assert config.ssl_config.client_key is not None
-    assert config.ssl_config.server_cert is not None
 
 
 class ArtifactFixture(object):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Current version 0.3.0 is supposed to work with Kubeflow 1.0. However, recently MLMD gRPC server has been updated to 0.21.1 in the manifests. This is incompatible with the MLMD Python SDK version 0.15.1 used by version 0.3.0. Therefore, in order to fix it, this PR bumps MLMD Python SDK version to 0.21.1 as well and fixes any issues related to it. The details is described in issue #213.

**Which issue(s) this PR fixes**:

Fixes #213 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update MLMD Python SDK to 0.21.1 so as to match [Kubeflow 1.0 version](https://github.com/kubeflow/manifests/pull/937) (Fixes #213).
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/metadata/214)
<!-- Reviewable:end -->
