### PR TITLE
Fix metadata frontend docker build failure on arm64

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,9 @@ COPY . .
 
 RUN npm install && npm rebuild node-sass && \
   npm run postinstall && \
-  CI=true npm run test:coverage && \
+  if [ "$(uname -m)" = "x86_64" ]; then \
+      CI=true npm run test:coverage; \
+  fi && \
   npm run build
 
 # Write commit and build date files and generate the dependency licenses files


### PR DESCRIPTION
When building current master branch metadata ui docker image on arm64, the building will fail at the coverage test. This commit fixes the build failure by not running the coverage test on arm64.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>


